### PR TITLE
Add explicit auth path selection to Alchemy skills

### DIFF
--- a/skills/agentic-gateway/SKILL.md
+++ b/skills/agentic-gateway/SKILL.md
@@ -15,7 +15,7 @@ A skill that lets agents easily access Alchemy's developer platform. The gateway
 
 ## Non-Bypass Rule
 
-When this skill is selected due to missing API key, do not use alternative Alchemy endpoints as an optimization.
+When this skill is selected because the user chose the agentic flow or because no API key is available, do not use alternative Alchemy endpoints as an optimization.
 Required flow: wallet -> SIWE -> request -> handle 402 payment -> retry same request.
 
 **Escape hatch:** Only exit the gateway flow if the user explicitly requests to switch to the `alchemy-api` skill with an API key. A key appearing in the environment or conversation does not automatically trigger a switch — the user must ask for it.
@@ -31,8 +31,9 @@ Required flow: wallet -> SIWE -> request -> handle 402 payment -> retry same req
 ## Required Preflight Check
 
 Before the first network call, internally evaluate:
-1. Is `ALCHEMY_API_KEY` absent? If no, this skill does not apply.
-2. Is a wallet confirmed with the user? If no, set `wallet=pending`.
+1. Did the user explicitly choose the agentic gateway flow? If yes, this skill applies.
+2. If not, is `ALCHEMY_API_KEY` absent? If no, this skill does not apply.
+3. Is a wallet confirmed with the user? If no, set `wallet=pending`.
 
 If the gateway route applies, demo and public endpoints are disallowed.
 If `wallet=pending`, you MUST follow [wallet-bootstrap](rules/wallet-bootstrap.md) and wait for user confirmation before proceeding. Do not read wallet files or generate keys.
@@ -119,4 +120,3 @@ Do not output this check to the user.
 - Never read or write wallet key files with Read/Write/Edit tools
 - Always ask the user about wallet choice before proceeding
 - See [wallet-bootstrap](rules/wallet-bootstrap.md) for the three wallet setup paths
-

--- a/skills/alchemy-api/SKILL.md
+++ b/skills/alchemy-api/SKILL.md
@@ -11,7 +11,14 @@ metadata:
 
 ## Mandatory Routing Gate (Hard Requirement)
 
-If `ALCHEMY_API_KEY` is unset or empty, you MUST use the `agentic-gateway` skill.
+Before the first network call or implementation step, you MUST ask the user the following question and wait for an explicit answer:
+
+> Do you want to use an existing Alchemy API key, or should I use the agentic gateway flow instead?
+
+If the user chooses the API key path, continue with this skill.
+If the user chooses the agentic gateway path, switch to the `agentic-gateway` skill immediately and follow its existing wallet flow.
+If the user chooses the API key path but `ALCHEMY_API_KEY` is unset or empty, tell them they can create a free API key at https://dashboard.alchemy.com/ or switch to the `agentic-gateway` skill.
+
 You MUST NOT call any keyless or public fallback (including `.../v2/demo`) unless the user explicitly asks for that endpoint.
 Execute no network calls before this gate is evaluated.
 
@@ -22,19 +29,25 @@ Execute no network calls before this gate is evaluated.
 ## Required Preflight Check
 
 Before the first network call, internally evaluate:
-1. Is `ALCHEMY_API_KEY` present and non-empty?
-2. If no, switch to the `agentic-gateway` skill immediately. Demo and public endpoints are disallowed.
+1. Has the user explicitly chosen API key or agentic gateway?
+2. If the user chose API key, is `ALCHEMY_API_KEY` present and non-empty?
+3. If the user chose agentic gateway, switch to the `agentic-gateway` skill immediately. Demo and public endpoints are disallowed.
+4. If the user chose API key but no key is available, do not proceed with API-key URLs until the user provides a key or switches to the gateway flow.
 
-Do not output this check to the user.
+Do not output this internal checklist to the user.
 
 ## Summary
 A self-contained guide for AI agents integrating Alchemy APIs using an API key. This file alone should be enough to ship a basic integration. Use the reference files for depth, edge cases, and advanced workflows.
 
+Developers can always create a free API key at https://dashboard.alchemy.com/.
+
 ## Before Making Any Request
 
-1. Check if `$ALCHEMY_API_KEY` is set (e.g., `echo $ALCHEMY_API_KEY`).
-2. If **not set**, do NOT proceed with API-key URLs. **Use the `agentic-gateway` skill instead** — it requires no API key.
-3. If set, use the Base URLs + Auth table below.
+1. Ask the user whether they want to use an existing Alchemy API key or the agentic gateway flow.
+2. If they choose the API key path, check if `$ALCHEMY_API_KEY` is set (e.g., `echo $ALCHEMY_API_KEY`).
+3. If they choose the API key path and no key is set, tell them they can create a free key at https://dashboard.alchemy.com/ or switch to the `agentic-gateway` skill.
+4. If they choose the agentic gateway flow, switch to the `agentic-gateway` skill and let it handle the existing wallet vs new wallet prompt.
+5. If they choose the API key path and the key is set, use the Base URLs + Auth table below.
 
 ## Do This First
 1. Choose the right product using the Endpoint Selector below.


### PR DESCRIPTION
## Summary
- ask users up front whether they want to use an existing Alchemy API key or the agentic gateway flow
- preserve the existing gateway wallet choice flow after users select the agentic path
- note near the top of the API-key skill that developers can always create a free key at dashboard.alchemy.com

## Testing
- docs-only skill update
- verified commit is SSH signed locally with `git log --show-signature`