### PR TITLE
[codex] Update README and sync alchemy-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Alchemy Skills
 
-Agent Skills for integrating [Alchemy](https://www.alchemy.com/) APIs into AI-powered applications. This repo contains three public skills plus a Codex plugin bundle derived from those source skills.
+Agent Skills for integrating [Alchemy](https://www.alchemy.com/) APIs into AI-powered applications. This repo contains public skills for using Alchemy with the official CLI, API key, agentic gateway, and Codex plugin.
 
 ## Skills
 
-### `skills/alchemy-codex`
-Codex-facing router skill for users who know they want to build with Alchemy but have not yet chosen between a standard API key flow and the Alchemy gateway flow.
+### `skills/alchemy-cli`
+CLI-first skill for agents with [`@alchemy/cli`](https://www.npmjs.com/package/@alchemy/cli) installed. Maps the Alchemy API surfaces to `alchemy <command>` invocations with structured JSON output.
 
-- **Auth**: Routes to the correct auth path before implementation
-- **Setup**: No separate setup; delegates to the chosen Alchemy skill
-- **Entry point**: [`skills/alchemy-codex/SKILL.md`](skills/alchemy-codex/SKILL.md)
+- **Auth**: CLI manages auth internally (API key, access key, x402 wallet)
+- **Setup**: `npm i -g @alchemy/cli`
+- **Entry point**: [`skills/alchemy-cli/SKILL.md`](skills/alchemy-cli/SKILL.md)
 
 ### `skills/alchemy-api`
 Traditional API key-based access to all Alchemy products: EVM JSON-RPC, Token API, NFT API, Prices API, Portfolio API, Webhooks, Solana, and more.
@@ -26,18 +26,34 @@ Lets agents easily access Alchemy's developer platform. Supports three access me
 - **Setup**: API key, or generate a wallet and fund it with USDC
 - **Entry point**: [`skills/agentic-gateway/SKILL.md`](skills/agentic-gateway/SKILL.md)
 
+### `skills/alchemy-codex`
+Codex-facing router skill for users who know they want to build with Alchemy but have not yet chosen between a standard API key flow and the Alchemy gateway flow.
+
+- **Auth**: Routes to the correct auth path before implementation
+- **Setup**: No separate setup; delegates to the chosen Alchemy skill
+- **Entry point**: [`skills/alchemy-codex/SKILL.md`](skills/alchemy-codex/SKILL.md)
+
 ## Which skill should I use?
 
 | Scenario | Skill |
 |---|---|
-| I want to use Alchemy in Codex but have not chosen an auth path yet | `alchemy-codex` |
+| I have `@alchemy/cli` installed | `alchemy-cli` |
 | I have an Alchemy API key | `alchemy-api` |
 | I'm building a traditional server or dApp | `alchemy-api` |
 | I'm an agent that needs easy access to Alchemy's developer platform | `agentic-gateway` |
 | I need API method details (params, responses) | `alchemy-api` (then cross-ref gateway URLs) |
 | I need SIWE auth or x402/MPP payment setup | `agentic-gateway` |
+| I want to use Alchemy in Codex but have not chosen an auth path yet | `alchemy-codex` |
 
 ## Installation
+
+Install the CLI directly if you want the primary local Alchemy workflow:
+
+```bash
+npm i -g @alchemy/cli
+```
+
+Or install the skills collection with `npx`:
 
 ```bash
 npx skills add alchemyplatform/skills --yes
@@ -49,72 +65,6 @@ Each source skill is self-contained and includes:
 - `LICENSE.txt`
 - `agents/openai.yaml` metadata for agent ecosystems that support it
 
-## Codex Plugin
-
-This repo also ships a Codex plugin bundle at [`plugins/alchemy`](plugins/alchemy) with marketplace metadata at [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
-
-The plugin packages the public Alchemy skills into a single installable unit. Its bundled skills are:
-
-- `alchemy-codex` for Codex-specific routing between Alchemy auth paths
-- `alchemy-api` for API key-based integrations
-- `agentic-gateway` for gateway-based access
-
-### Install In OpenAI Codex
-
-Clone this repo, then install the bundled plugin into your home-local Codex plugins directory:
-
-```bash
-git clone https://github.com/alchemyplatform/skills.git
-cd skills
-python3 scripts/install_codex_plugin.py
-```
-
-That command:
-
-- copies [`plugins/alchemy`](plugins/alchemy) to `~/plugins/alchemy`
-- creates or updates `~/.agents/plugins/marketplace.json`
-- registers the plugin as `alchemy` in the local Codex marketplace
-
-If you already have a local `alchemy` plugin and want to replace it:
-
-```bash
-python3 scripts/install_codex_plugin.py --force
-```
-
-If you prefer not to install into your home directory, you can keep the plugin repo-local and point Codex at this repo's [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
-
-## Recommended Layout
-
-Based on the structure used in [openai/skills](https://github.com/openai/skills), the recommended long-term layout in this repo is:
-
-- keep reusable source skills under [`skills/`](skills)
-- keep Codex-specific packaging under [`plugins/alchemy`](plugins/alchemy)
-- keep marketplace metadata under [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json)
-
-For naming, `alchemy` is the right plugin name. It is short, matches the product brand, and leaves room for the individual packaged skills to keep more specific names like `alchemy-api` and `agentic-gateway`.
-
-The Codex-only router skill is intentionally named `alchemy-codex` to avoid ambiguity with future non-Codex packaging, including Claude-oriented distributions.
-
-## Syncing the Plugin Bundle
-
-When source skills change, resync the installable plugin bundle with:
-
-```bash
-python3 plugins/alchemy/scripts/sync_from_catalog.py
-```
-
-The sync script copies these source skills into the plugin bundle and removes stale generated skill directories:
-
-- `alchemy-codex`
-- `alchemy-api`
-- `agentic-gateway`
-
-To refresh an already-installed home-local Codex plugin after pulling new changes:
-
-```bash
-python3 scripts/install_codex_plugin.py --force
-```
-
 ## Specification
 
 These skills follow the [Agent Skills specification](https://agentskills.io/specification). See [spec/agent-skills-spec.md](spec/agent-skills-spec.md) for details.
@@ -124,6 +74,7 @@ These skills follow the [Agent Skills specification](https://agentskills.io/spec
 - [Developer docs](https://www.alchemy.com/docs)
 - [Get Started guide](https://www.alchemy.com/docs/get-started)
 - [Create a free API key](https://dashboard.alchemy.com/)
+- [Install the Alchemy CLI](https://www.npmjs.com/package/@alchemy/cli)
 
 ## License
 

--- a/plugins/alchemy/skills/alchemy-codex/SKILL.md
+++ b/plugins/alchemy/skills/alchemy-codex/SKILL.md
@@ -41,3 +41,9 @@ Then route as follows:
 - Webhooks / Notify setup
 - Account Kit and wallet infrastructure
 - agentic gateway access via x402 or MPP
+
+## Codex bundle notes
+
+- Treat this as a thin Codex router skill, not a place for detailed API or payment-flow instructions
+- Route implementation details to `alchemy-api` or `agentic-gateway` as soon as the auth path is clear
+- Keep this bundled copy aligned with `skills/alchemy-codex/SKILL.md`

--- a/skills/alchemy-cli/SKILL.md
+++ b/skills/alchemy-cli/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: alchemy-cli
+description: The Alchemy CLI (`@alchemy/cli`) is installed. Use `alchemy` commands for all blockchain data, wallet, webhook, and app management tasks instead of curl or raw HTTP. Covers auth setup, command discovery via `agent-prompt`, and common task-to-command mappings.
+license: MIT
+compatibility: Requires `@alchemy/cli` (npm i -g @alchemy/cli). Works across Claude Code, Cursor, Codex, and any agent with shell access.
+metadata:
+  author: alchemyplatform
+  version: "1.0"
+---
+# Alchemy CLI
+
+The [Alchemy CLI](https://www.npmjs.com/package/@alchemy/cli) (`@alchemy/cli`) is installed. Use it for all Alchemy API interactions instead of curl or raw HTTP.
+
+## Install
+
+```bash
+npm i -g @alchemy/cli
+```
+
+## Bootstrap
+
+Run this at the start of any session to get the full command contract (every command, flag, auth method, error code, and example):
+
+```bash
+alchemy --json --no-interactive agent-prompt
+```
+
+## Execution Rules
+
+- ALWAYS pass `--json --no-interactive` on every command
+- Parse stdout as JSON on exit code 0
+- Parse stderr as JSON on nonzero exit code
+- NEVER run bare `alchemy` without `--json --no-interactive`
+- NEVER use curl or raw HTTP when an `alchemy` CLI command exists for the task
+
+## Preflight
+
+Before the first command, check auth readiness:
+
+```bash
+alchemy --json --no-interactive setup status
+```
+
+If `complete` is false, follow the `nextCommands` in the response to configure auth.
+
+## Auth Setup
+
+The fastest way to authenticate is via browser login:
+
+```bash
+alchemy auth login
+```
+
+This opens a browser to authenticate with your Alchemy account and automatically configures the CLI with your credentials.
+
+To check auth status: `alchemy auth status`
+To log out: `alchemy auth logout`
+
+### Alternative auth methods
+
+| Method | Config command | Env var | Used by |
+|--------|---------------|---------|---------|
+| Browser login | `alchemy auth login` | -- | All commands (provides both API key and access key) |
+| API key | `alchemy config set api-key <key>` | `ALCHEMY_API_KEY` | balance, tx, block, rpc, tokens, nfts, transfers, prices, portfolio, simulate, solana |
+| Access key | `alchemy config set access-key <key>` | `ALCHEMY_ACCESS_KEY` | apps, network list |
+| Webhook key | `alchemy config set webhook-api-key <key>` | `ALCHEMY_WEBHOOK_API_KEY` | webhooks |
+| x402 wallet | `alchemy wallet generate` then `alchemy config set x402 true` | `ALCHEMY_WALLET_KEY` | balance, tx, block, rpc, tokens, nfts, transfers |
+
+Get API/access keys at [dashboard.alchemy.com](https://dashboard.alchemy.com/).
+
+## Task-to-Command Map
+
+### Node (EVM)
+
+| Task | Command |
+|------|---------|
+| ETH balance | `alchemy balance <address>` |
+| Transaction details | `alchemy tx <hash>` |
+| Transaction receipt | `alchemy receipt <hash>` |
+| Block details | `alchemy block <number\|latest>` |
+| Gas prices | `alchemy gas` |
+| Event logs | `alchemy logs --address <addr> --from-block <n> --to-block <n>` |
+| Raw JSON-RPC | `alchemy rpc <method> [params...]` |
+| Trace methods | `alchemy trace <method> [params...]` |
+| Debug methods | `alchemy debug <method> [params...]` |
+
+### Data
+
+| Task | Command |
+|------|---------|
+| ERC-20 balances | `alchemy tokens balances <address>` |
+| ERC-20 balances (formatted) | `alchemy tokens balances <address> --metadata` |
+| Token metadata | `alchemy tokens metadata <contract>` |
+| Token allowance | `alchemy tokens allowance --owner <addr> --spender <addr> --contract <addr>` |
+| List owned NFTs | `alchemy nfts <address>` |
+| NFT metadata | `alchemy nfts metadata --contract <addr> --token-id <id>` |
+| NFT contract metadata | `alchemy nfts contract <address>` |
+| Transfer history | `alchemy transfers <address> --category erc20,erc721` |
+| Spot prices by symbol | `alchemy prices symbol ETH,USDC` |
+| Spot prices by address | `alchemy prices address --addresses '<json>'` |
+| Historical prices | `alchemy prices historical --body '<json>'` |
+| Token portfolio | `alchemy portfolio tokens --body '<json>'` |
+| NFT portfolio | `alchemy portfolio nfts --body '<json>'` |
+| Portfolio transactions | `alchemy portfolio transactions --body '<json>'` |
+| Simulate asset changes | `alchemy simulate asset-changes --tx '<json>'` |
+| Simulate execution | `alchemy simulate execution --tx '<json>'` |
+
+### Solana
+
+| Task | Command |
+|------|---------|
+| Solana JSON-RPC | `alchemy solana rpc <method> [params...]` |
+| Solana DAS (NFTs/assets) | `alchemy solana das <method> '<json>'` |
+
+### Webhooks
+
+| Task | Command |
+|------|---------|
+| List webhooks | `alchemy webhooks list` |
+| Create webhook | `alchemy webhooks create --body '<json>'` |
+| Update webhook | `alchemy webhooks update --body '<json>'` |
+| Delete webhook | `alchemy webhooks delete <id>` |
+
+### App Management
+
+| Task | Command |
+|------|---------|
+| List apps | `alchemy apps list` |
+| Create app | `alchemy apps create --name "My App" --networks eth-mainnet` |
+| Update app | `alchemy apps update <id> --name "New Name"` |
+| Delete app | `alchemy apps delete <id>` |
+| List networks | `alchemy network list` |
+
+### CLI Admin
+
+| Task | Command |
+|------|---------|
+| Check for CLI updates | `alchemy update-check` |
+| View config | `alchemy config list` |
+| Reset config | `alchemy config reset --yes` |
+| CLI version | `alchemy version` |
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Force JSON output |
+| `--no-interactive` | Disable prompts and REPL |
+| `-n, --network <network>` | Target network (default: `eth-mainnet`) |
+| `--api-key <key>` | Override API key per command |
+| `--access-key <key>` | Override access key per command |
+| `--x402` | Use x402 wallet auth for this command |
+| `--timeout <ms>` | Request timeout in milliseconds |
+| `-q, --quiet` | Suppress non-essential output |
+| `--verbose` | Log request/response details to stderr |
+
+## Error Handling
+
+Errors return structured JSON on stderr. Key error codes:
+
+| Code | Retryable | Recovery |
+|------|-----------|----------|
+| `AUTH_REQUIRED` | No | Set `ALCHEMY_API_KEY` or run `alchemy config set api-key <key>` |
+| `RATE_LIMITED` | Yes | Wait and retry with backoff |
+| `PAYMENT_REQUIRED` | No | Fund x402 wallet or switch to API key auth |
+| `RPC_ERROR` | No | Check method, params, and network |
+| `NETWORK_ERROR` | Yes | Check connection and retry |
+| `SETUP_REQUIRED` | No | Run `alchemy --json setup status` and follow `nextCommands` |
+
+For the full error code list, see `agent-prompt` output.
+
+## Official Links
+
+- [CLI on npm](https://www.npmjs.com/package/@alchemy/cli)
+- [Alchemy docs](https://www.alchemy.com/docs)
+- [Get API key](https://dashboard.alchemy.com/)

--- a/skills/alchemy-codex/SKILL.md
+++ b/skills/alchemy-codex/SKILL.md
@@ -41,3 +41,9 @@ Then route as follows:
 - Webhooks / Notify setup
 - Account Kit and wallet infrastructure
 - agentic gateway access via x402 or MPP
+
+## Codex bundle notes
+
+- Treat this as a thin Codex router skill, not a place for detailed API or payment-flow instructions
+- Route implementation details to `alchemy-api` or `agentic-gateway` as soon as the auth path is clear
+- When the router changes, keep the bundled copy in `plugins/alchemy/skills/alchemy-codex` aligned with this source skill


### PR DESCRIPTION
## Summary

- reorder the skills section in the root README to surface `alchemy-cli` first and move the `alchemy-codex` chooser guidance to the bottom of the table
- make CLI installation the primary install path, keep the `npx skills add` path as the secondary option, and add the official npm link to the links section
- remove Codex plugin maintenance details from the public README and keep the remaining Codex-router guidance with the `alchemy-codex` skill files
- sync `skills/alchemy-cli/SKILL.md` from the published upstream repo state

## Why

The root README had accumulated internal Codex plugin packaging details that are not useful for external readers. This change makes the public docs CLI-first, keeps the README focused on user-facing install and skill-selection guidance, and moves the small amount of relevant Codex-router context to the router skill itself.

## Impact

Users landing on the repo now see the CLI-first path first, the skill selection guidance is cleaner, and the published `alchemy-cli` skill is present on this branch so the README links resolve correctly.

## Validation

- inspected the staged diff for the README and skill files
- confirmed `skills/alchemy-cli/SKILL.md` matches `origin/main` byte-for-byte
- ran `git diff --cached --check`
- verified the commit is signed with the configured SSH signing key
