### PR TITLE
[codex] Clean up README and Codex router docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,8 @@
 # Alchemy Skills
 
-Agent Skills for integrating [Alchemy](https://www.alchemy.com/) APIs into AI-powered applications. This repo contains three public skills plus a Codex plugin bundle derived from those source skills.
+Agent Skills for integrating [Alchemy](https://www.alchemy.com/) APIs into AI-powered applications. This repo contains public skills for using Alchemy with the official CLI, API key, agentic gateway, and Codex plugin.
 
 ## Skills
-
-### `skills/alchemy-codex`
-Codex-facing router skill for users who know they want to build with Alchemy but have not yet chosen between a standard API key flow and the Alchemy gateway flow.
-
-- **Auth**: Routes to the correct auth path before implementation
-- **Setup**: No separate setup; delegates to the chosen Alchemy skill
-- **Entry point**: [`skills/alchemy-codex/SKILL.md`](skills/alchemy-codex/SKILL.md)
-
-### `skills/alchemy-api`
-Traditional API key-based access to all Alchemy products: EVM JSON-RPC, Token API, NFT API, Prices API, Portfolio API, Webhooks, Solana, and more.
-
-- **Auth**: API key in URL or header
-- **Setup**: Create a free key at [dashboard.alchemy.com](https://dashboard.alchemy.com/)
-- **Entry point**: [`skills/alchemy-api/SKILL.md`](skills/alchemy-api/SKILL.md)
 
 ### `skills/alchemy-cli`
 CLI-first skill for agents with [`@alchemy/cli`](https://www.npmjs.com/package/@alchemy/cli) installed. Maps the Alchemy API surfaces to `alchemy <command>` invocations with structured JSON output.
@@ -24,6 +10,13 @@ CLI-first skill for agents with [`@alchemy/cli`](https://www.npmjs.com/package/@
 - **Auth**: CLI manages auth internally (API key, access key, x402 wallet)
 - **Setup**: `npm i -g @alchemy/cli`
 - **Entry point**: [`skills/alchemy-cli/SKILL.md`](skills/alchemy-cli/SKILL.md)
+
+### `skills/alchemy-api`
+Traditional API key-based access to all Alchemy products: EVM JSON-RPC, Token API, NFT API, Prices API, Portfolio API, Webhooks, Solana, and more.
+
+- **Auth**: API key in URL or header
+- **Setup**: Create a free key at [dashboard.alchemy.com](https://dashboard.alchemy.com/)
+- **Entry point**: [`skills/alchemy-api/SKILL.md`](skills/alchemy-api/SKILL.md)
 
 ### `skills/agentic-gateway`
 Lets agents easily access Alchemy's developer platform. Supports three access methods: API key, x402 protocol (USDC payments), or MPP protocol (Tempo/Stripe payments). Prompts the user to choose their preferred protocol.
@@ -33,19 +26,34 @@ Lets agents easily access Alchemy's developer platform. Supports three access me
 - **Setup**: API key, or generate a wallet and fund it with USDC
 - **Entry point**: [`skills/agentic-gateway/SKILL.md`](skills/agentic-gateway/SKILL.md)
 
+### `skills/alchemy-codex`
+Codex-facing router skill for users who know they want to build with Alchemy but have not yet chosen between a standard API key flow and the Alchemy gateway flow.
+
+- **Auth**: Routes to the correct auth path before implementation
+- **Setup**: No separate setup; delegates to the chosen Alchemy skill
+- **Entry point**: [`skills/alchemy-codex/SKILL.md`](skills/alchemy-codex/SKILL.md)
+
 ## Which skill should I use?
 
 | Scenario | Skill |
 |---|---|
 | I have `@alchemy/cli` installed | `alchemy-cli` |
-| I want to use Alchemy in Codex but have not chosen an auth path yet | `alchemy-codex` |
 | I have an Alchemy API key | `alchemy-api` |
 | I'm building a traditional server or dApp | `alchemy-api` |
 | I'm an agent that needs easy access to Alchemy's developer platform | `agentic-gateway` |
 | I need API method details (params, responses) | `alchemy-api` (then cross-ref gateway URLs) |
 | I need SIWE auth or x402/MPP payment setup | `agentic-gateway` |
+| I want to use Alchemy in Codex but have not chosen an auth path yet | `alchemy-codex` |
 
 ## Installation
+
+Install the CLI directly if you want the primary local Alchemy workflow:
+
+```bash
+npm i -g @alchemy/cli
+```
+
+Or install the skills collection with `npx`:
 
 ```bash
 npx skills add alchemyplatform/skills --yes
@@ -57,72 +65,6 @@ Each source skill is self-contained and includes:
 - `LICENSE.txt`
 - `agents/openai.yaml` metadata for agent ecosystems that support it
 
-## Codex Plugin
-
-This repo also ships a Codex plugin bundle at [`plugins/alchemy`](plugins/alchemy) with marketplace metadata at [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
-
-The plugin packages the public Alchemy skills into a single installable unit. Its bundled skills are:
-
-- `alchemy-codex` for Codex-specific routing between Alchemy auth paths
-- `alchemy-api` for API key-based integrations
-- `agentic-gateway` for gateway-based access
-
-### Install In OpenAI Codex
-
-Clone this repo, then install the bundled plugin into your home-local Codex plugins directory:
-
-```bash
-git clone https://github.com/alchemyplatform/skills.git
-cd skills
-python3 scripts/install_codex_plugin.py
-```
-
-That command:
-
-- copies [`plugins/alchemy`](plugins/alchemy) to `~/plugins/alchemy`
-- creates or updates `~/.agents/plugins/marketplace.json`
-- registers the plugin as `alchemy` in the local Codex marketplace
-
-If you already have a local `alchemy` plugin and want to replace it:
-
-```bash
-python3 scripts/install_codex_plugin.py --force
-```
-
-If you prefer not to install into your home directory, you can keep the plugin repo-local and point Codex at this repo's [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
-
-## Recommended Layout
-
-Based on the structure used in [openai/skills](https://github.com/openai/skills), the recommended long-term layout in this repo is:
-
-- keep reusable source skills under [`skills/`](skills)
-- keep Codex-specific packaging under [`plugins/alchemy`](plugins/alchemy)
-- keep marketplace metadata under [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json)
-
-For naming, `alchemy` is the right plugin name. It is short, matches the product brand, and leaves room for the individual packaged skills to keep more specific names like `alchemy-api` and `agentic-gateway`.
-
-The Codex-only router skill is intentionally named `alchemy-codex` to avoid ambiguity with future non-Codex packaging, including Claude-oriented distributions.
-
-## Syncing the Plugin Bundle
-
-When source skills change, resync the installable plugin bundle with:
-
-```bash
-python3 plugins/alchemy/scripts/sync_from_catalog.py
-```
-
-The sync script copies these source skills into the plugin bundle and removes stale generated skill directories:
-
-- `alchemy-codex`
-- `alchemy-api`
-- `agentic-gateway`
-
-To refresh an already-installed home-local Codex plugin after pulling new changes:
-
-```bash
-python3 scripts/install_codex_plugin.py --force
-```
-
 ## Specification
 
 These skills follow the [Agent Skills specification](https://agentskills.io/specification). See [spec/agent-skills-spec.md](spec/agent-skills-spec.md) for details.
@@ -132,6 +74,7 @@ These skills follow the [Agent Skills specification](https://agentskills.io/spec
 - [Developer docs](https://www.alchemy.com/docs)
 - [Get Started guide](https://www.alchemy.com/docs/get-started)
 - [Create a free API key](https://dashboard.alchemy.com/)
+- [Install the Alchemy CLI](https://www.npmjs.com/package/@alchemy/cli)
 
 ## License
 

--- a/plugins/alchemy/skills/alchemy-codex/SKILL.md
+++ b/plugins/alchemy/skills/alchemy-codex/SKILL.md
@@ -41,3 +41,9 @@ Then route as follows:
 - Webhooks / Notify setup
 - Account Kit and wallet infrastructure
 - agentic gateway access via x402 or MPP
+
+## Codex bundle notes
+
+- Treat this as a thin Codex router skill, not a place for detailed API or payment-flow instructions
+- Route implementation details to `alchemy-api` or `agentic-gateway` as soon as the auth path is clear
+- Keep this bundled copy aligned with `skills/alchemy-codex/SKILL.md`

--- a/skills/alchemy-codex/SKILL.md
+++ b/skills/alchemy-codex/SKILL.md
@@ -41,3 +41,9 @@ Then route as follows:
 - Webhooks / Notify setup
 - Account Kit and wallet infrastructure
 - agentic gateway access via x402 or MPP
+
+## Codex bundle notes
+
+- Treat this as a thin Codex router skill, not a place for detailed API or payment-flow instructions
+- Route implementation details to `alchemy-api` or `agentic-gateway` as soon as the auth path is clear
+- When the router changes, keep the bundled copy in `plugins/alchemy/skills/alchemy-codex` aligned with this source skill


### PR DESCRIPTION
## Summary

- reorder the root README skill list to surface `alchemy-cli`, `alchemy-api`, `agentic-gateway`, then `alchemy-codex`
- move the `alchemy-codex` chooser row to the bottom of the skill-selection table and make CLI install the primary installation path
- remove internal Codex plugin packaging and maintenance guidance from the public README, while keeping the small amount of router-specific guidance in the `alchemy-codex` skill files
- add the official npm link for the Alchemy CLI to the end of the Official Links section

## Why

The root README had accumulated internal Codex plugin context that is not useful for external readers. This keeps the public documentation focused on which skill to use and how to install it, while moving the remaining Codex-router context closer to the router skill itself.

## Impact

Repo visitors now see the CLI-first workflow first, the skill matrix is easier to scan, and the README no longer carries internal plugin-maintenance instructions.

## Validation

- reviewed the diff against `origin/main`
- ran `git diff --cached --check`
- verified the commit is signed with the configured SSH signing key
