### PR TITLE
[Writer] Weekly skills update — 2026-04-08

### DIFF
--- a/skills/alchemy-api/references/node-overview.md
+++ b/skills/alchemy-api/references/node-overview.md
@@ -4,7 +4,7 @@ name: node-apis
 description: Core JSON-RPC and WebSocket APIs for EVM chains via Alchemy node endpoints, plus Debug/Trace and utility methods. Use when building EVM integrations that need standard RPC calls, real-time subscriptions, enhanced Alchemy methods, or execution-level tracing.
 tags: []
 related: []
-updated: 2026-02-14
+updated: 2026-04-08
 metadata:
   author: alchemyplatform
   version: "1.0"
@@ -21,6 +21,9 @@ Core JSON-RPC and WebSocket APIs for EVM chains via Alchemy node endpoints, plus
 4. [node-utility-api.md](node-utility-api.md) - Convenience endpoints like bulk transaction receipts.
 5. [node-debug-api.md](node-debug-api.md) - Debug tracing for transaction simulation and execution insight.
 6. [node-trace-api.md](node-trace-api.md) - Trace-level details for internal calls and state diffs.
+
+## Recently Added Chains
+- **Injective** — Cosmos SDK-based L1 with full EVM compatibility. Supports standard `eth_*` JSON-RPC methods. Use endpoint pattern `injective-mainnet`. See [Injective API Overview](https://www.alchemy.com/docs/chains/injective/injective-api-overview).
 
 ## How to Use This Skill
 - Start with `node-json-rpc.md` for base connectivity and request patterns.

--- a/skills/alchemy-api/references/operational-supported-networks.md
+++ b/skills/alchemy-api/references/operational-supported-networks.md
@@ -9,7 +9,7 @@ tags:
 related:
   - node-json-rpc.md
   - solana-rpc.md
-updated: 2026-04-01
+updated: 2026-04-08
 ---
 # Supported Networks
 
@@ -162,6 +162,7 @@ hyperliquid-mainnet
 hyperliquid-testnet
 ink-mainnet
 ink-sepolia
+injective-mainnet
 lens-mainnet
 lens-sepolia
 linea-mainnet

--- a/skills/alchemy-api/references/wallets-bundler.md
+++ b/skills/alchemy-api/references/wallets-bundler.md
@@ -1,27 +1,37 @@
 ---
 id: references/wallets-bundler.md
 name: 'Bundler'
-description: 'A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets.'
+description: 'A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets. Supports EntryPoint v0.6, v0.7, and v0.8.'
 tags:
   - alchemy
   - wallets
 related:
   - wallets-smart-wallets.md
   - wallets-gas-manager.md
-updated: 2026-02-05
+updated: 2026-04-08
 ---
 # Bundler
 
 ## Summary
-A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets.
+A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets. Powered by Rundler, Alchemy's production-grade ERC-4337 bundler.
+
+## Supported EntryPoint Versions
+- **v0.6** — original ERC-4337 EntryPoint
+- **v0.7** — updated gas model and validation logic
+- **v0.8** — latest version with additional optimizations
+
+When configuring the bundler, ensure you target the correct EntryPoint version for your smart account implementation.
 
 ## Primary Use Cases
-- AA transaction submission.
-- UserOperation lifecycle handling.
+- AA transaction submission via standard ERC-4337 JSON-RPC endpoints.
+- UserOperation lifecycle handling (submit, track, drop-and-replace).
 
 ## Integration Notes
-- Ensure correct chain configuration and entry point.
+- Ensure correct chain configuration and EntryPoint version.
 - Monitor bundler latency and failures.
+- Use `eth_getUserOperationByHash` to poll UserOp status; if still null after timeout, drop and replace with higher fees.
+- For `Replacement Underpriced` errors, increase both `maxFeePerGas` and `maxPriorityFeePerGas` by at least 10%.
+- Bundler APIs are available in `@account-kit/infra`. For higher-level abstractions, use Wallet APIs or aa-sdk.
 
 ## Related Files
 - `wallets-smart-wallets.md`
@@ -29,3 +39,4 @@ A bundler aggregates and submits account abstraction user operations. Use this w
 
 ## Official Docs
 - [Bundler Overview](https://www.alchemy.com/docs/wallets/transactions/low-level-infra/bundler/overview)
+- [Bundler FAQs](https://www.alchemy.com/docs/wallets/reference/bundler-faqs)

--- a/skills/alchemy-api/references/wallets-gas-manager.md
+++ b/skills/alchemy-api/references/wallets-gas-manager.md
@@ -1,14 +1,14 @@
 ---
 id: references/wallets-gas-manager.md
 name: 'Gas Manager'
-description: 'Gas Manager (paymaster) enables gas sponsorship and cost control for smart wallet flows.'
+description: 'Gas Manager (paymaster) enables gas sponsorship and cost control for smart wallet flows, including ERC-20 token gas payments and BSO (Bundler Sponsorship) policies.'
 tags:
   - alchemy
   - wallets
 related:
   - wallets-smart-wallets.md
   - wallets-bundler.md
-updated: 2026-02-05
+updated: 2026-04-08
 ---
 # Gas Manager
 
@@ -18,10 +18,19 @@ Gas Manager (paymaster) enables gas sponsorship and cost control for smart walle
 ## Primary Use Cases
 - Gasless user onboarding.
 - Sponsoring specific methods or contracts.
+- ERC-20 token gas payments (pay gas with any supported token).
+- BSO (Bundler Sponsorship) policies for EIP-7702 undelegation.
 
 ## Integration Notes
 - Define strict sponsorship policies.
 - Monitor for abuse and enforce caps.
+
+## ERC-20 Token Gas Payment — Revert Risk
+When using **post-operation** mode for ERC-20 gas payments:
+- If a token approval is batched with your calls and any call reverts, the approval is also reverted. The paymaster cannot collect the token payment, and **you (the policy owner) pay the gas cost** without receiving token compensation.
+- If a sufficient allowance already exists (e.g., from threshold mode), the paymaster collects payment even if the batch reverts.
+- **Use post-operation** when operations are unlikely to revert (works with all ERC-20 tokens).
+- **Use pre-operation** when operations may revert — the token transfer happens before execution so the paymaster is always compensated.
 
 ## Related Files
 - `wallets-smart-wallets.md`
@@ -29,3 +38,4 @@ Gas Manager (paymaster) enables gas sponsorship and cost control for smart walle
 
 ## Official Docs
 - [Gas Manager Admin API](https://www.alchemy.com/docs/wallets/low-level-infra/gas-manager/policy-management/api-endpoints)
+- [Pay Gas With Any Token](https://www.alchemy.com/docs/wallets/transactions/pay-gas-with-any-token)

--- a/skills/alchemy-api/references/wallets-wallet-apis.md
+++ b/skills/alchemy-api/references/wallets-wallet-apis.md
@@ -8,16 +8,24 @@ tags:
 related:
   - wallets-account-kit.md
   - operational-auth-and-keys.md
-updated: 2026-04-01
+updated: 2026-04-08
 ---
 # Wallet APIs
 
 ## Summary
-High-level wallet APIs enable programmatic wallet operations such as signing, transaction preparation, or account management. This guide stays minimal and focuses on integration awareness.
+High-level wallet APIs enable programmatic wallet operations such as signing, transaction preparation, account management, and EIP-7702 delegation/undelegation. This guide stays minimal and focuses on integration awareness.
 
 ## Primary Use Cases
 - Server-side transaction preparation.
 - Delegated signing or session-based flows.
+- EIP-7702 account delegation and undelegation.
+
+## EIP-7702 Undelegation
+Undelegation removes smart contract delegation from an EIP-7702 account by delegating to the zero address (`0x0000...0000`), restoring it to a plain EOA. Key details:
+- Gas is sponsored through a **BSO (Bundler Sponsorship) policy** — the account does not need native tokens.
+- Requires **enterprise plan** — sponsored undelegation is gated to enterprise customers.
+- Available via both the client SDK (`@alchemy/wallet-apis`) and REST API.
+- For advanced control, use `wallet_prepareCalls` + `wallet_sendPreparedCalls` to inspect and sign the authorization separately.
 
 ## Integration Notes
 - Prefer client-side signing for user security.


### PR DESCRIPTION
Weekly skills reference update based on merged docs PRs #1178, #1179, #1180, #1183, #1191.

**Files updated:**
- `wallets-bundler.md` — Added EntryPoint v0.8 support, documented all three supported versions (v0.6/v0.7/v0.8), added troubleshooting guidance
- `wallets-gas-manager.md` — Added ERC-20 token gas payment revert risk guidance (post-op vs pre-op mode), BSO policies for undelegation
- `wallets-wallet-apis.md` — Added EIP-7702 undelegation feature (sponsored via BSO, enterprise-gated)
- `operational-supported-networks.md` — Added Injective (injective-mainnet) to Data API networks list
- `node-overview.md` — Added Injective to recently added chains section

**Source PRs:**
- PR #1191: Injective API docs (new chain)
- PR #1180: ERC-4337 EntryPoint v0.8 support
- PR #1179: 7702 sponsored undelegation
- PR #1178: ERC-20 paymaster revert risk clarification
- PR #1183: undelegateAccount override fix (minor, covered by wallet-apis update)