### PR TITLE
[Writer] Weekly skills update — Sui gRPC, Solana webhooks GA, Tenderly debugging

### DIFF
--- a/skills/alchemy-api/SKILL.md
+++ b/skills/alchemy-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alchemy-api
-description: Integrates Alchemy blockchain APIs using an API key. Requires $ALCHEMY_API_KEY to be set; if unavailable, use the agentic-gateway skill instead. Use when user asks about EVM JSON-RPC calls, token balances, NFT ownership or metadata, transfer history, token prices, portfolio data, transaction simulation, webhooks, Solana RPC, or any Alchemy product integration. Covers base URLs, authentication, endpoint selection, pagination, and common patterns.
+description: Integrates Alchemy blockchain APIs using an API key. Requires $ALCHEMY_API_KEY to be set; if unavailable, use the agentic-gateway skill instead. Use when user asks about EVM JSON-RPC calls, token balances, NFT ownership or metadata, transfer history, token prices, portfolio data, transaction simulation, webhooks, Solana RPC, Sui gRPC, or any Alchemy product integration. Covers base URLs, authentication, endpoint selection, pagination, and common patterns.
 license: MIT
 compatibility: Requires network access and $ALCHEMY_API_KEY environment variable. Works across Claude.ai, Claude Code, and API.
 metadata:
@@ -67,6 +67,7 @@ Developers can always create a free API key at https://dashboard.alchemy.com/.
 | BNB RPC (WSS) | `wss://bnb-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY` | API key in URL | Subscriptions and realtime. |
 | Solana RPC (HTTPS) | `https://solana-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY` | API key in URL | Solana JSON-RPC. |
 | Solana Yellowstone gRPC | `https://solana-mainnet.g.alchemy.com` | `X-Token: $ALCHEMY_API_KEY` | gRPC streaming (Yellowstone). |
+| Sui gRPC | `sui-mainnet.g.alchemy.com:443` | `Authorization: Bearer $ALCHEMY_API_KEY` | Sui gRPC API (objects, txs, balances, streaming). |
 | NFT API | `https://<network>.g.alchemy.com/nft/v3/$ALCHEMY_API_KEY` | API key in URL | NFT ownership and metadata. |
 | Prices API | `https://api.g.alchemy.com/prices/v1/$ALCHEMY_API_KEY` | API key in URL | Prices by symbol or address. |
 | Portfolio API | `https://api.g.alchemy.com/data/v1/$ALCHEMY_API_KEY` | API key in URL | Multi-chain wallet views. |
@@ -88,6 +89,9 @@ Developers can always create a free API key at https://dashboard.alchemy.com/.
 | Simulate tx | `alchemy_simulateAssetChanges` | `references/data-simulation-api.md` |
 | Create webhook | `POST /create-webhook` | `references/webhooks-details.md` |
 | Solana NFT data | `getAssetsByOwner` (DAS) | `references/solana-das-api.md` |
+| Sui objects/txs | `GetObject`, `GetTransaction` (gRPC) | `references/sui-grpc-objects-and-ledger.md` |
+| Sui balances | `GetBalance`, `ListBalances` (gRPC) | `references/sui-grpc-state-and-balances.md` |
+| Sui checkpoints stream | `SubscribeCheckpoints` (gRPC) | `references/sui-grpc-subscriptions.md` |
 
 ## One-File Quickstart (Copy/Paste)
 
@@ -179,13 +183,14 @@ export function verify(rawBody: string, signature: string, secret: string) {
 
 ## Skill Map
 
-For the complete index of all 82+ reference files organized by product area (Node, Data, Webhooks, Solana, Wallets, Rollups, Recipes, Operational, Ecosystem), see `references/skill-map.md`.
+For the complete index of all 90+ reference files organized by product area (Node, Data, Webhooks, Solana, Sui gRPC, Wallets, Rollups, Recipes, Operational, Ecosystem), see `references/skill-map.md`.
 
 Quick category overview:
 - **Node**: JSON-RPC, WebSocket, Debug, Trace, Enhanced APIs, Utility
 - **Data**: NFT, Portfolio, Prices, Simulation, Token, Transfers
 - **Webhooks**: Address Activity, Custom (GraphQL), NFT Activity, Payloads, Signatures
 - **Solana**: JSON-RPC, DAS, Yellowstone gRPC (streaming), Wallets
+- **Sui gRPC**: Objects, Transactions, Balances, Move Packages, Name Service, Subscriptions, Signature Verification
 - **Wallets**: Account Kit, Bundler, Gas Manager, Smart Wallets
 - **Rollups**: L2/L3 deployment overview
 - **Recipes**: 10 end-to-end integration workflows

--- a/skills/alchemy-api/references/skill-map.md
+++ b/skills/alchemy-api/references/skill-map.md
@@ -53,6 +53,19 @@ Complete index of all reference files organized by product area. Use the Endpoin
 | `references/solana-rpc.md` | Solana JSON-RPC | Standard Solana JSON-RPC endpoints for account, program, and transaction data |
 | `references/solana-wallets.md` | Solana Wallet Integration | High-level guidance for integrating Solana wallets and signing transactions |
 
+## Sui gRPC
+| File | Name | Short Description |
+| --- | --- | --- |
+| `references/sui-grpc-overview.md` | sui-grpc | High-performance gRPC API for Sui blockchain access. Supports objects, transactions, balances, Move packages, name service, subscriptions, and signature verification. Use when building Sui integrations that need typed, efficient access with streaming and field masking |
+| `references/sui-grpc-quickstart.md` | Sui gRPC Quickstart | Endpoints, authentication, and first gRPC calls for Sui |
+| `references/sui-grpc-objects-and-ledger.md` | Sui gRPC Objects and Ledger | LedgerService: query objects, transactions, checkpoints, and epochs |
+| `references/sui-grpc-transactions.md` | Sui gRPC Transactions | TransactionExecutionService: execute and simulate Sui transactions |
+| `references/sui-grpc-state-and-balances.md` | Sui gRPC State and Balances | StateService: coin balances, dynamic fields, and owned objects |
+| `references/sui-grpc-move-packages.md` | Sui gRPC Move Packages | MovePackageService: inspect Move packages, functions, and data types |
+| `references/sui-grpc-name-service.md` | Sui gRPC Name Service | NameService: resolve SuiNS names to addresses and reverse lookups |
+| `references/sui-grpc-subscriptions.md` | Sui gRPC Subscriptions | SubscriptionService: stream real-time checkpoint data |
+| `references/sui-grpc-signature-verification.md` | Sui gRPC Signature Verification | SignatureVerificationService: verify user signatures including ZkLogin |
+
 ## Wallets
 | File | Name | Short Description |
 | --- | --- | --- |

--- a/skills/alchemy-api/references/sui-grpc-move-packages.md
+++ b/skills/alchemy-api/references/sui-grpc-move-packages.md
@@ -1,0 +1,39 @@
+---
+id: references/sui-grpc-move-packages.md
+name: 'Sui gRPC Move Packages'
+description: 'MovePackageService methods for inspecting Move packages, functions, and data types on Sui via gRPC.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - sui-grpc-overview.md
+updated: 2026-04-15
+---
+# Sui gRPC — Move Packages (MovePackageService)
+
+## Summary
+Inspect Move packages, functions, and data types on Sui.
+
+## Methods
+
+| gRPC Method | JSON-RPC Equivalent | Description |
+| --- | --- | --- |
+| `GetPackage` | `sui_getNormalizedMoveModulesByPackage` | Fetch a Move package by ID |
+| `GetFunction` | `sui_getNormalizedMoveFunction` | Fetch a function definition by package, module, and name |
+| `GetDatatype` | `sui_getNormalizedMoveStruct` | Fetch a Move struct/datatype definition |
+| `ListPackageVersions` | No equivalent | List all versions of a package |
+
+## Key Patterns
+- `GetFunction` requires `package_id`, `module_name`, and `name`.
+- `GetDatatype` requires `package_id`, `module_name`, and `name`.
+- Use `ListPackageVersions` to discover upgrade history for a package.
+
+## Service Path
+`sui.rpc.v2.MovePackageService`
+
+## Related Files
+- `sui-grpc-overview.md`
+
+## Official Docs
+- [Move Packages](https://www.alchemy.com/docs/reference/sui-grpc-move-packages)

--- a/skills/alchemy-api/references/sui-grpc-name-service.md
+++ b/skills/alchemy-api/references/sui-grpc-name-service.md
@@ -1,0 +1,32 @@
+---
+id: references/sui-grpc-name-service.md
+name: 'Sui gRPC Name Service'
+description: 'NameService methods for resolving SuiNS names to addresses and reverse lookups via gRPC.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - sui-grpc-overview.md
+updated: 2026-04-15
+---
+# Sui gRPC — Name Service
+
+## Summary
+Resolve SuiNS names to addresses and perform reverse lookups.
+
+## Methods
+
+| gRPC Method | JSON-RPC Equivalent | Description |
+| --- | --- | --- |
+| `LookupName` | `suix_resolveNameServiceAddress` | Resolve a SuiNS name (e.g., `example.sui`) to its address |
+| `ReverseLookupName` | `suix_resolveNameServiceNames` | Resolve an address to its SuiNS name |
+
+## Service Path
+`sui.rpc.v2.NameService`
+
+## Related Files
+- `sui-grpc-overview.md`
+
+## Official Docs
+- [Name Service](https://www.alchemy.com/docs/reference/sui-grpc-name-service)

--- a/skills/alchemy-api/references/sui-grpc-objects-and-ledger.md
+++ b/skills/alchemy-api/references/sui-grpc-objects-and-ledger.md
@@ -1,0 +1,44 @@
+---
+id: references/sui-grpc-objects-and-ledger.md
+name: 'Sui gRPC Objects and Ledger'
+description: 'LedgerService methods for querying objects, transactions, checkpoints, and epochs on Sui via gRPC.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - sui-grpc-overview.md
+  - sui-grpc-transactions.md
+updated: 2026-04-15
+---
+# Sui gRPC — Objects and Ledger (LedgerService)
+
+## Summary
+The `LedgerService` provides methods for querying objects, transactions, checkpoints, epochs, and chain metadata.
+
+## Methods
+
+| gRPC Method | JSON-RPC Equivalent | Description |
+| --- | --- | --- |
+| `GetObject` | `sui_getObject` | Fetch a single object by ID (optionally at a version) |
+| `BatchGetObjects` | `sui_multiGetObjects` | Fetch multiple objects in one request |
+| `GetTransaction` | `sui_getTransactionBlock` | Fetch a transaction by digest |
+| `BatchGetTransactions` | `sui_multiGetTransactionBlocks` | Fetch multiple transactions |
+| `GetCheckpoint` | `sui_getCheckpoint` | Fetch a checkpoint by sequence number or digest |
+| `GetEpoch` | No equivalent | Fetch epoch metadata |
+| `GetServiceInfo` | `sui_getChainIdentifier` | Chain metadata, current checkpoint height, epoch |
+
+## Key Patterns
+- Use `read_mask` on all methods to request only needed fields (reduces response size).
+- Use `BatchGetObjects` / `BatchGetTransactions` for multi-item lookups instead of individual calls.
+- `GetServiceInfo` requires no fields — use it as a health check or to get current chain state.
+
+## Service Path
+`sui.rpc.v2.LedgerService`
+
+## Related Files
+- `sui-grpc-overview.md`
+- `sui-grpc-transactions.md`
+
+## Official Docs
+- [Objects and Ledger](https://www.alchemy.com/docs/reference/sui-grpc-objects-and-ledger)

--- a/skills/alchemy-api/references/sui-grpc-overview.md
+++ b/skills/alchemy-api/references/sui-grpc-overview.md
@@ -1,0 +1,45 @@
+---
+id: references/sui-grpc-overview.md
+name: sui-grpc
+description: 'High-performance gRPC API for querying and executing on Sui via Alchemy. Supports objects, transactions, balances, Move packages, name service, subscriptions, and signature verification. Use when building Sui integrations that need typed, efficient access with streaming and field masking.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - operational-supported-networks.md
+  - operational-auth-and-keys.md
+updated: 2026-04-15
+metadata:
+  author: alchemyplatform
+  version: "1.0"
+---
+# Sui gRPC
+
+## Summary
+Sui gRPC is a high-performance API for Sui blockchain access using Protocol Buffers and gRPC. It provides strongly typed, binary-encoded access to objects, transactions, balances, Move packages, name resolution, real-time checkpoint streaming, and signature verification.
+
+## Why Use Sui gRPC Over JSON-RPC
+- **Strongly typed** — Protocol Buffers provide strict typing and schema validation.
+- **Efficient serialization** — Binary encoding reduces payload size vs JSON.
+- **Streaming** — `SubscribeCheckpoints` delivers real-time checkpoint data via server-streaming RPC.
+- **Field masking** — Use `read_mask` to request only the fields you need.
+- **Batch operations** — Fetch multiple objects or transactions in a single request.
+
+## References (Recommended Order)
+1. [sui-grpc-quickstart.md](sui-grpc-quickstart.md) — First gRPC call, endpoints, auth.
+2. [sui-grpc-objects-and-ledger.md](sui-grpc-objects-and-ledger.md) — LedgerService: objects, transactions, checkpoints, epochs.
+3. [sui-grpc-transactions.md](sui-grpc-transactions.md) — Execute and simulate transactions.
+4. [sui-grpc-state-and-balances.md](sui-grpc-state-and-balances.md) — Coin balances, dynamic fields, owned objects.
+5. [sui-grpc-move-packages.md](sui-grpc-move-packages.md) — Inspect Move packages and functions.
+6. [sui-grpc-name-service.md](sui-grpc-name-service.md) — Resolve SuiNS names.
+7. [sui-grpc-subscriptions.md](sui-grpc-subscriptions.md) — Real-time checkpoint streaming.
+8. [sui-grpc-signature-verification.md](sui-grpc-signature-verification.md) — Verify user signatures.
+
+## Cross-References
+- `operational-supported-networks.md` — Sui mainnet/testnet availability.
+- `operational-auth-and-keys.md` — API key management.
+
+## Official Docs
+- [Sui gRPC Overview](https://www.alchemy.com/docs/reference/sui-grpc-overview)
+- [Sui gRPC Quickstart](https://www.alchemy.com/docs/reference/sui-grpc-quickstart)

--- a/skills/alchemy-api/references/sui-grpc-quickstart.md
+++ b/skills/alchemy-api/references/sui-grpc-quickstart.md
@@ -1,0 +1,63 @@
+---
+id: references/sui-grpc-quickstart.md
+name: 'Sui gRPC Quickstart'
+description: 'Get started with Sui gRPC — endpoints, authentication, and first calls.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - sui-grpc-overview.md
+  - sui-grpc-objects-and-ledger.md
+  - operational-auth-and-keys.md
+updated: 2026-04-15
+---
+# Sui gRPC Quickstart
+
+## Summary
+Connect to Alchemy's Sui gRPC API and make your first calls.
+
+## Prerequisites
+- An Alchemy API key.
+- A gRPC client library (or `grpcurl` for CLI testing).
+- [Sui gRPC proto definitions](https://github.com/MystenLabs/sui-apis) cloned locally (grpcurl requires `.proto` files).
+
+## Endpoints
+
+| Network | Endpoint |
+| --- | --- |
+| Mainnet | `sui-mainnet.g.alchemy.com:443` |
+| Testnet | `sui-testnet.g.alchemy.com:443` |
+
+## Authentication
+Bearer token in the request metadata header:
+```
+-H "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+## Quick Verification
+Call `GetServiceInfo` to verify your connection:
+```bash
+grpcurl \
+  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -import-path proto \
+  -proto sui/rpc/v2/ledger_service.proto \
+  -d '{}' \
+  sui-mainnet.g.alchemy.com:443 \
+  sui.rpc.v2.LedgerService/GetServiceInfo
+```
+
+Returns chain name, chain ID, current checkpoint height, and epoch.
+
+## Common First Calls
+- **Get an object**: `LedgerService/GetObject` with `object_id` and optional `read_mask`.
+- **Get a transaction**: `LedgerService/GetTransaction` with `digest`.
+- **Check balance**: `StateService/GetBalance` with `owner` and `coin_type`.
+
+## Related Files
+- `sui-grpc-overview.md`
+- `sui-grpc-objects-and-ledger.md`
+- `operational-auth-and-keys.md`
+
+## Official Docs
+- [Sui gRPC Quickstart](https://www.alchemy.com/docs/reference/sui-grpc-quickstart)

--- a/skills/alchemy-api/references/sui-grpc-signature-verification.md
+++ b/skills/alchemy-api/references/sui-grpc-signature-verification.md
@@ -1,0 +1,36 @@
+---
+id: references/sui-grpc-signature-verification.md
+name: 'Sui gRPC Signature Verification'
+description: 'SignatureVerificationService for verifying user signatures on Sui, including ZkLogin support.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - sui-grpc-overview.md
+updated: 2026-04-15
+---
+# Sui gRPC — Signature Verification
+
+## Summary
+Verify user signatures against messages and addresses on Sui. Supports standard signatures and ZkLogin signatures.
+
+## Methods
+
+| gRPC Method | JSON-RPC Equivalent | Description |
+| --- | --- | --- |
+| `VerifySignature` | No equivalent | Verify a user signature against a message and address |
+
+## VerifySignature
+- Requires `address`, `signature` (BCS-encoded), and `message` (BCS-encoded).
+- Optional `jwks` parameter for ZkLogin signature verification (Active JSON Web Keys).
+- Returns `is_valid` boolean and `reason` string on failure.
+
+## Service Path
+`sui.rpc.v2.SignatureVerificationService`
+
+## Related Files
+- `sui-grpc-overview.md`
+
+## Official Docs
+- [Signature Verification](https://www.alchemy.com/docs/reference/sui-grpc-signature-verification)

--- a/skills/alchemy-api/references/sui-grpc-state-and-balances.md
+++ b/skills/alchemy-api/references/sui-grpc-state-and-balances.md
@@ -1,0 +1,42 @@
+---
+id: references/sui-grpc-state-and-balances.md
+name: 'Sui gRPC State and Balances'
+description: 'StateService methods for querying coin balances, dynamic fields, and owned objects on Sui via gRPC.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - sui-grpc-overview.md
+  - sui-grpc-objects-and-ledger.md
+updated: 2026-04-15
+---
+# Sui gRPC — State and Balances (StateService)
+
+## Summary
+Query coin balances, dynamic fields, and owned objects on Sui.
+
+## Methods
+
+| gRPC Method | JSON-RPC Equivalent | Description |
+| --- | --- | --- |
+| `GetBalance` | `suix_getBalance` | Get balance of a specific coin type for an owner |
+| `ListBalances` | `suix_getAllBalances`, `suix_getCoins`, `suix_getAllCoins` | List all coin balances for an owner (paginated) |
+| `GetCoinInfo` | `suix_getCoinMetadata`, `suix_getTotalSupply` | Get coin metadata and total supply |
+| `ListDynamicFields` | `suix_getDynamicFields` | List dynamic fields of an object (paginated) |
+| `ListOwnedObjects` | `suix_getOwnedObjects` | List objects owned by an address (paginated) |
+
+## Key Patterns
+- `GetBalance` requires both `owner` and `coin_type` (e.g., `0x2::sui::SUI`).
+- Paginated methods (`ListBalances`, `ListDynamicFields`, `ListOwnedObjects`) accept `page_size` and `page_token`.
+- Use `read_mask` on `ListOwnedObjects` to control which object fields are returned.
+
+## Service Path
+`sui.rpc.v2.StateService`
+
+## Related Files
+- `sui-grpc-overview.md`
+- `sui-grpc-objects-and-ledger.md`
+
+## Official Docs
+- [State and Balances](https://www.alchemy.com/docs/reference/sui-grpc-state-and-balances)

--- a/skills/alchemy-api/references/sui-grpc-subscriptions.md
+++ b/skills/alchemy-api/references/sui-grpc-subscriptions.md
@@ -1,0 +1,37 @@
+---
+id: references/sui-grpc-subscriptions.md
+name: 'Sui gRPC Subscriptions'
+description: 'SubscriptionService for streaming real-time Sui checkpoint data via server-streaming gRPC.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - sui-grpc-overview.md
+updated: 2026-04-15
+---
+# Sui gRPC — Subscriptions (SubscriptionService)
+
+## Summary
+Stream real-time checkpoint data from Sui via server-streaming gRPC.
+
+## Methods
+
+| gRPC Method | JSON-RPC Equivalent | Description |
+| --- | --- | --- |
+| `SubscribeCheckpoints` | No equivalent | Stream new checkpoints as they are finalized |
+
+## Key Patterns
+- This is a long-lived server-streaming RPC — the connection stays open and delivers checkpoints in real time.
+- Use `read_mask` to control which checkpoint fields are included.
+- Response includes a `cursor` for resuming the stream after disconnection.
+- Handle reconnection and backpressure in your client.
+
+## Service Path
+`sui.rpc.v2.SubscriptionService`
+
+## Related Files
+- `sui-grpc-overview.md`
+
+## Official Docs
+- [Subscriptions](https://www.alchemy.com/docs/reference/sui-grpc-subscriptions)

--- a/skills/alchemy-api/references/sui-grpc-transactions.md
+++ b/skills/alchemy-api/references/sui-grpc-transactions.md
@@ -1,0 +1,44 @@
+---
+id: references/sui-grpc-transactions.md
+name: 'Sui gRPC Transactions'
+description: 'TransactionExecutionService for executing and simulating Sui transactions via gRPC.'
+tags:
+  - alchemy
+  - sui
+  - grpc
+related:
+  - sui-grpc-overview.md
+  - sui-grpc-objects-and-ledger.md
+updated: 2026-04-15
+---
+# Sui gRPC — Transactions (TransactionExecutionService)
+
+## Summary
+Execute and simulate transactions on Sui.
+
+## Methods
+
+| gRPC Method | JSON-RPC Equivalent | Description |
+| --- | --- | --- |
+| `ExecuteTransaction` | `sui_executeTransactionBlock` | Submit a signed transaction for execution |
+| `SimulateTransaction` | `sui_dryRunTransactionBlock` | Simulate execution without submitting (gas estimation, effect preview) |
+
+## ExecuteTransaction
+- Requires `transaction` (BCS-encoded) and `signatures` array.
+- Optional `read_mask` to control response fields.
+
+## SimulateTransaction
+- Requires `transaction` (BCS-encoded).
+- Optional `do_gas_selection` for automatic gas coin selection.
+- Optional `checks` to enable/disable transaction validation checks.
+- Returns simulated effects, command outputs, and suggested gas price.
+
+## Service Path
+`sui.rpc.v2.TransactionExecutionService`
+
+## Related Files
+- `sui-grpc-overview.md`
+- `sui-grpc-objects-and-ledger.md`
+
+## Official Docs
+- [Transactions](https://www.alchemy.com/docs/reference/sui-grpc-transactions)

--- a/skills/alchemy-api/references/wallets-overview.md
+++ b/skills/alchemy-api/references/wallets-overview.md
@@ -4,7 +4,7 @@ name: wallets
 description: Integration guide for Alchemy Wallets and smart wallet tooling including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart wallets into your application.
 tags: []
 related: []
-updated: 2026-02-14
+updated: 2026-04-15
 metadata:
   author: alchemyplatform
   version: "1.0"
@@ -23,6 +23,13 @@ High-level integration notes for Alchemy Wallets and smart wallet tooling. This 
 6. [wallets-wallet-apis.md](wallets-wallet-apis.md) - Basic wallet API concepts.
 7. [wallets-supported-chains.md](wallets-supported-chains.md) - Wallet-specific chain support notes.
 8. [wallets-solana-notes.md](wallets-solana-notes.md) - Solana wallet considerations (high-level).
+
+## Debugging
+- The Transaction Lifecycle Dashboard integrates with **Tenderly** for debugging failed Wallet API transactions (PAYG/Enterprise tiers).
+- **Debug** button: opens Tenderly debugger for onchain reverts (transactions with a hash).
+- **Simulate** button: runs Tenderly simulation for offchain failures (`UserOperationExecutionError`, no tx hash).
+- Use when diagnosing opaque reverts, `AA23` errors, or batched call failures.
+- [Debug with Tenderly docs](https://www.alchemy.com/docs/wallets/transactions/debug-transactions/debug-with-tenderly)
 
 ## Cross-References
 - `node-apis` skill for EVM connectivity.

--- a/skills/alchemy-api/references/webhooks-address-activity.md
+++ b/skills/alchemy-api/references/webhooks-address-activity.md
@@ -10,7 +10,7 @@ related:
   - webhooks-webhook-payloads.md
   - webhooks-verify-signatures.md
   - data-transfers-api.md
-updated: 2026-02-05
+updated: 2026-04-15
 ---
 # Address Activity Webhooks
 
@@ -32,10 +32,15 @@ Update addresses (`PATCH /update-webhook-addresses`) with:
 - `addresses_to_add[]` (required, empty array if none)
 - `addresses_to_remove[]` (required, empty array if none)
 
+## Chain Support
+- Supports 30+ EVM chains (ETH, ERC-20, ERC-721, ERC-1155 transfers).
+- Now available on Solana (no longer beta).
+
 ## Configuration Notes
 - Provide one or more addresses to watch.
 - Choose event categories (native, ERC-20, ERC-721, ERC-1155).
 - Decide if you need internal transfers.
+- Maximum of 100,000 addresses per webhook.
 
 ## Payload Expectations
 - Expect an array of activities with tx hash, from/to, value, token metadata.


### PR DESCRIPTION
## Changes

### New files (9) — Sui gRPC references
- `sui-grpc-overview.md` — Overview and routing for the new Sui gRPC API
- `sui-grpc-quickstart.md` — Endpoints, auth, first calls
- `sui-grpc-objects-and-ledger.md` — LedgerService methods
- `sui-grpc-transactions.md` — TransactionExecutionService methods
- `sui-grpc-state-and-balances.md` — StateService methods
- `sui-grpc-move-packages.md` — MovePackageService methods
- `sui-grpc-name-service.md` — NameService methods
- `sui-grpc-subscriptions.md` — SubscriptionService (checkpoint streaming)
- `sui-grpc-signature-verification.md` — SignatureVerificationService

Source: PR #1194 added 9 new Sui gRPC docs pages.

### Updated files (4)
- `SKILL.md` — Added Sui gRPC to description, base URLs table, endpoint selector, and skill map overview
- `skill-map.md` — Added Sui gRPC section with all 9 reference files
- `webhooks-address-activity.md` — Solana webhooks now GA (was beta), added 100k address limit note (PR #1214)
- `wallets-overview.md` — Added Tenderly debugging section for failed Wallet API transactions (PR #1182)

### Not updated (no material skills impact)
- PR #1190/1206/1205 (MCP Server rewrites) — build-with-ai tutorials, no skills references affected
- PR #1207 (PAYG webhooks limit to 100) — minor pricing table change, not material for agent API usage