### PR TITLE
[Writer] Weekly skills update — 2026-04-22

### DIFF
--- a/plugins/alchemy/skills/alchemy-api/SKILL.md
+++ b/plugins/alchemy/skills/alchemy-api/SKILL.md
@@ -239,7 +239,7 @@ Quick category overview:
 - **Webhooks**: Address Activity, Custom (GraphQL), NFT Activity, Payloads, Signatures
 - **Solana**: JSON-RPC, DAS, Yellowstone gRPC (streaming), Wallets
 - **Sui gRPC**: Objects, Transactions, Balances, Move Packages, Name Service, Subscriptions, Signature Verification
-- **Wallets**: Account Kit, Bundler, Gas Manager, Smart Wallets
+- **Wallets**: Account Kit, Bundler, Gas Manager, Wallet APIs (formerly "Smart Wallets")
 - **Rollups**: L2/L3 deployment overview
 - **Recipes**: 10 end-to-end integration workflows
 - **Operational**: Auth, Rate Limits, Monitoring, Best Practices

--- a/plugins/alchemy/skills/alchemy-api/references/node-overview.md
+++ b/plugins/alchemy/skills/alchemy-api/references/node-overview.md
@@ -4,7 +4,7 @@ name: node-apis
 description: Core JSON-RPC and WebSocket APIs for EVM chains via Alchemy node endpoints, plus Debug/Trace and utility methods. Use when building EVM integrations that need standard RPC calls, real-time subscriptions, enhanced Alchemy methods, or execution-level tracing.
 tags: []
 related: []
-updated: 2026-04-08
+updated: 2026-04-22
 metadata:
   author: alchemyplatform
   version: "1.0"
@@ -22,8 +22,13 @@ Core JSON-RPC and WebSocket APIs for EVM chains via Alchemy node endpoints, plus
 5. [node-debug-api.md](node-debug-api.md) - Debug tracing for transaction simulation and execution insight.
 6. [node-trace-api.md](node-trace-api.md) - Trace-level details for internal calls and state diffs.
 
-## Recently Added Chains
-- **Injective** — Cosmos SDK-based L1 with full EVM compatibility. Supports standard `eth_*` JSON-RPC methods. Use endpoint pattern `injective-mainnet`. See [Injective API Overview](https://www.alchemy.com/docs/chains/injective/injective-api-overview).
+## Recently Added / Updated Chains
+- **Injective** — Cosmos SDK-based L1 with full EVM compatibility. Supports standard `eth_*` JSON-RPC methods. Use endpoint pattern `injective-mainnet`. A few methods (`eth_getBlockReceipts`, `eth_syncing`, `net_listening`) are testnet-only today. Debug namespace (`debug_*`) methods are served by the standalone **Debug API product**, not the chain spec — see [Debug API Quickstart](https://www.alchemy.com/docs/reference/debug-api-quickstart). Overview: [Injective API Overview](https://www.alchemy.com/docs/chains/injective/injective-api-overview).
+- **Gensyn** — mainnet is live. Endpoint `gensyn-mainnet` (chain ID `685689`); `gensyn-testnet` remains available. See the [Gensyn quickstart](https://www.alchemy.com/docs/chains/gensyn/gensyn-api-quickstart).
+- **MegaETH** — supports `eth_getWithdrawalProof` (20 CU). See [Compute Unit Costs](https://www.alchemy.com/docs/reference/compute-unit-costs#megaeth-specific-methods).
+
+## Recently Deprecated Chains
+- **Arbitrum Nova** — deprecated. Nova endpoints are no longer supported; see the [Arbitrum Nova deprecation notice](https://www.alchemy.com/docs/reference/arbitrum-nova/arbitrum-nova-deprecation-notice).
 
 ## How to Use This Skill
 - Start with `node-json-rpc.md` for base connectivity and request patterns.

--- a/plugins/alchemy/skills/alchemy-api/references/node-websocket-subscriptions.md
+++ b/plugins/alchemy/skills/alchemy-api/references/node-websocket-subscriptions.md
@@ -10,13 +10,23 @@ tags:
 related:
   - node-json-rpc.md
   - webhooks-details.md
-updated: 2026-02-23
+updated: 2026-04-22
 ---
 # WebSocket Subscriptions
 
 Real-time blockchain events via WebSocket. No polling required.
 
 **Base URL**: `wss://<network>.g.alchemy.com/v2/$ALCHEMY_API_KEY`
+
+## Billing & Scope Guidance
+Alchemy bills WebSocket subscriptions on the bandwidth they deliver, so broad streams can scale compute unit usage quickly. Keep subscriptions narrow by default:
+
+- Prefer filtered subscriptions (address, topic, or `alchemy_minedTransactions` filters) over network-wide streams.
+- Prefer hash-only payloads when full transaction objects are not required (e.g., `hashesOnly: true` for `alchemy_pendingTransactions` / `alchemy_minedTransactions`).
+- Set [usage limits](https://www.alchemy.com/docs/how-to-set-usage-limits-and-alerts-for-your-account) and alerts before deploying high-volume streams.
+- Broad subscription streams can generate far more ongoing traffic than equivalent HTTP polling, because the server keeps pushing every matching event until you unsubscribe.
+
+See [Compute Unit Costs — Webhooks and Subscription APIs](https://www.alchemy.com/docs/reference/compute-unit-costs#webhooks-and-subscription-apis) for pricing details.
 
 ---
 
@@ -192,7 +202,7 @@ ws.on("message", (data) => {
 
 - Subscriptions are stateful. Handle reconnects and resubscribe after reconnect.
 - You may receive duplicate events on reconnect. De-duplicate by block hash or log index.
-- `newPendingTransactions` is very high volume. Use tight filters if available.
+- `newPendingTransactions` is very high volume. Use tight filters if available, or switch to `alchemy_pendingTransactions` with `addresses` and `hashesOnly: true` to keep bandwidth (and billing) predictable.
 - If WebSockets are unavailable, fall back to HTTP polling with coarse intervals and backoff.
 
 ## Official Docs

--- a/plugins/alchemy/skills/alchemy-api/references/operational-supported-networks.md
+++ b/plugins/alchemy/skills/alchemy-api/references/operational-supported-networks.md
@@ -9,7 +9,7 @@ tags:
 related:
   - node-json-rpc.md
   - solana-rpc.md
-updated: 2026-04-08
+updated: 2026-04-22
 ---
 # Supported Networks
 
@@ -20,6 +20,9 @@ Alchemy supports multiple EVM and Solana networks. Always verify network availab
 - Use chain-specific base URLs (e.g., `eth-mainnet`, `polygon-mainnet`).
 - Use testnets for QA.
 - Not all products are available on every chain.
+
+## Recently Deprecated / Removed
+- **Arbitrum Nova** — deprecated. Nova endpoints (`arbnova-mainnet`, `ARBNOVA_MAINNET`) are no longer supported across Node, Wallets (Bundler, Gas Manager), and related products. See the [Arbitrum Nova deprecation notice](https://www.alchemy.com/docs/reference/arbitrum-nova/arbitrum-nova-deprecation-notice) for migration guidance.
 
 
 ## Spec-Derived Network Enums (Partial)
@@ -32,7 +35,6 @@ ETH_SEPOLIA
 ETH_HOLESKY
 ARB_MAINNET
 ARB_SEPOLIA
-ARBNOVA_MAINNET
 MATIC_MAINNET
 MATIC_MUMBAI
 OPT_MAINNET
@@ -100,7 +102,6 @@ aptos-mainnet
 aptos-testnet
 arb-mainnet
 arb-sepolia
-arbnova-mainnet
 arc-testnet
 astar-mainnet
 avax-fuji

--- a/plugins/alchemy/skills/alchemy-api/references/recipes-subscribe-pending-txs.md
+++ b/plugins/alchemy/skills/alchemy-api/references/recipes-subscribe-pending-txs.md
@@ -8,7 +8,7 @@ tags:
   - recipe
 related:
   - node-websocket-subscriptions.md
-updated: 2026-02-05
+updated: 2026-04-22
 ---
 # Recipe: Subscribe to Pending Transactions
 
@@ -21,8 +21,10 @@ Stream pending transactions in real time and optionally enrich them with transac
 
 ## Steps
 1. Connect to WebSocket endpoint.
-2. Subscribe to `newPendingTransactions`.
+2. Subscribe to `newPendingTransactions` (or `alchemy_pendingTransactions` with address filters for narrower scope).
 3. Optionally call `eth_getTransactionByHash` to enrich data.
+
+> **Billing note:** WebSocket subscriptions are billed on delivered bandwidth. `newPendingTransactions` is extremely high volume on mainnets — prefer `alchemy_pendingTransactions` with `addresses` and `hashesOnly: true`, and set [usage limits](https://www.alchemy.com/docs/how-to-set-usage-limits-and-alerts-for-your-account) before deploying. See `node-websocket-subscriptions.md` for details.
 
 ## Example (TypeScript)
 ```ts

--- a/plugins/alchemy/skills/alchemy-api/references/skill-map.md
+++ b/plugins/alchemy/skills/alchemy-api/references/skill-map.md
@@ -73,12 +73,12 @@ Complete index of all reference files organized by product area. Use the Endpoin
 ## Wallets
 | File | Name | Short Description |
 | --- | --- | --- |
-| `references/wallets-overview.md` | wallets | Integration guide for Alchemy Wallets and smart wallet tooling including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart wallets into your application |
+| `references/wallets-overview.md` | wallets | Integration guide for Alchemy Wallet APIs (formerly "Smart Wallets") including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart accounts into your application |
 | `references/wallets-account-kit.md` | Account Kit | Account Kit is Alchemy's wallet SDK for onboarding users and managing wallet UX. Use it for embedded wallet flows or seamless authentication |
-| `references/wallets-bundler.md` | Bundler | A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets |
+| `references/wallets-bundler.md` | Bundler | A bundler aggregates and submits account abstraction user operations. Use this when integrating smart accounts (Wallet APIs) |
 | `references/wallets-details.md` | Wallets Overview | Alchemy Wallets tooling helps developers embed or integrate wallets with minimal infrastructure. This section is intentionally basic and focuses on integration touchpoints |
 | `references/wallets-gas-manager.md` | Gas Manager | Gas Manager (paymaster) enables gas sponsorship and cost control for smart wallet flows |
-| `references/wallets-smart-wallets.md` | Smart Wallets | Smart wallets (account abstraction) enable programmable accounts with features like session keys, batched transactions, and gas sponsorship |
+| `references/wallets-smart-wallets.md` | Smart Wallets (concept) | Smart wallets (account abstraction) are programmable accounts with features like session keys, batched transactions, and gas sponsorship. Alchemy exposes these via the Wallet APIs product |
 | `references/wallets-solana-notes.md` | Solana Wallet Notes | Solana wallet integration differs from EVM. Use Solana-specific tooling and RPC semantics |
 | `references/wallets-supported-chains.md` | Wallet Supported Chains | Wallet tooling may support a subset of chains compared to raw RPC. Always confirm chain support before launch |
 | `references/wallets-wallet-apis.md` | Wallet APIs | High-level wallet APIs enable programmatic wallet operations such as signing, transaction preparation, or account management. This guide stays minimal and focuses on integration awareness |

--- a/plugins/alchemy/skills/alchemy-api/references/sui-grpc-quickstart.md
+++ b/plugins/alchemy/skills/alchemy-api/references/sui-grpc-quickstart.md
@@ -10,7 +10,7 @@ related:
   - sui-grpc-overview.md
   - sui-grpc-objects-and-ledger.md
   - operational-auth-and-keys.md
-updated: 2026-04-15
+updated: 2026-04-22
 ---
 # Sui gRPC Quickstart
 
@@ -53,6 +53,19 @@ Returns chain name, chain ID, current checkpoint height, and epoch.
 - **Get an object**: `LedgerService/GetObject` with `object_id` and optional `read_mask`.
 - **Get a transaction**: `LedgerService/GetTransaction` with `digest`.
 - **Check balance**: `StateService/GetBalance` with `owner` and `coin_type`.
+
+## `read_mask` format
+`read_mask` is a protobuf [FieldMask](https://protobuf.dev/reference/protobuf/google.protobuf/#field-mask). In JSON (grpcurl, gRPC-web, etc.) encode it as an **object with a `paths` array**, not a comma-separated string:
+
+```bash
+# Correct — FieldMask JSON form
+grpcurl -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -import-path proto -proto sui/rpc/v2/ledger_service.proto \
+  -d '{"object_id": "0x5", "read_mask": {"paths": ["object_id", "version", "digest", "owner"]}}' \
+  sui-mainnet.g.alchemy.com:443 sui.rpc.v2.LedgerService/GetObject
+```
+
+Passing `read_mask` as a bare string (`"object_id,version,..."`) will be rejected.
 
 ## Related Files
 - `sui-grpc-overview.md`

--- a/plugins/alchemy/skills/alchemy-api/references/wallets-bundler.md
+++ b/plugins/alchemy/skills/alchemy-api/references/wallets-bundler.md
@@ -1,19 +1,19 @@
 ---
 id: references/wallets-bundler.md
 name: 'Bundler'
-description: 'A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets. Supports EntryPoint v0.6, v0.7, and v0.8.'
+description: 'A bundler aggregates and submits account abstraction user operations. Use this when integrating smart accounts (Wallet APIs). Supports EntryPoint v0.6, v0.7, and v0.8.'
 tags:
   - alchemy
   - wallets
 related:
   - wallets-smart-wallets.md
   - wallets-gas-manager.md
-updated: 2026-04-08
+updated: 2026-04-22
 ---
 # Bundler
 
 ## Summary
-A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets. Powered by Rundler, Alchemy's production-grade ERC-4337 bundler.
+A bundler aggregates and submits account abstraction user operations. Use this when integrating smart accounts via Alchemy Wallet APIs. Powered by Rundler, Alchemy's production-grade ERC-4337 bundler.
 
 ## Supported EntryPoint Versions
 - **v0.6** — original ERC-4337 EntryPoint

--- a/plugins/alchemy/skills/alchemy-api/references/wallets-details.md
+++ b/plugins/alchemy/skills/alchemy-api/references/wallets-details.md
@@ -10,12 +10,14 @@ related:
   - wallets-smart-wallets.md
   - wallets-bundler.md
   - wallets-gas-manager.md
-updated: 2026-02-05
+updated: 2026-04-22
 ---
 # Wallets Overview
 
+> **Naming note:** Alchemy rebranded "Smart Wallets" to **Wallet APIs**. Both terms may still appear in older material; prefer "Wallet APIs" going forward.
+
 ## Summary
-Alchemy Wallets tooling helps developers embed or integrate wallets with minimal infrastructure. This section is intentionally basic and focuses on integration touchpoints.
+Alchemy Wallet APIs help developers embed or integrate wallets with minimal infrastructure. This section is intentionally basic and focuses on integration touchpoints.
 
 ## Primary Use Cases
 - User onboarding with embedded wallets.
@@ -23,7 +25,7 @@ Alchemy Wallets tooling helps developers embed or integrate wallets with minimal
 - Gas sponsorship and transaction bundling.
 
 ## When To Use / Not Use
-- Use when you want a turnkey wallet stack.
+- Use when you want an end-to-end, batteries-included wallet stack (signer → smart account → bundler → paymaster).
 - Avoid if you already have a wallet provider and only need RPC/data.
 
 ## Related Files
@@ -33,4 +35,4 @@ Alchemy Wallets tooling helps developers embed or integrate wallets with minimal
 - `wallets-gas-manager.md`
 
 ## Official Docs
-- [Smart Wallets](https://www.alchemy.com/docs/wallets)
+- [Wallet APIs](https://www.alchemy.com/docs/wallets)

--- a/plugins/alchemy/skills/alchemy-api/references/wallets-gas-manager.md
+++ b/plugins/alchemy/skills/alchemy-api/references/wallets-gas-manager.md
@@ -8,7 +8,7 @@ tags:
 related:
   - wallets-smart-wallets.md
   - wallets-bundler.md
-updated: 2026-04-08
+updated: 2026-04-22
 ---
 # Gas Manager
 
@@ -20,6 +20,9 @@ Gas Manager (paymaster) enables gas sponsorship and cost control for smart walle
 - Sponsoring specific methods or contracts.
 - ERC-20 token gas payments (pay gas with any supported token).
 - BSO (Bundler Sponsorship) policies for EIP-7702 undelegation.
+
+## BSO Chain Support
+Bundler Sponsored Operations (BSOs) are a bundler feature and are supported on **every chain that has both bundler and gas sponsorship support**, with the exception of **MegaETH** (coming soon). Always confirm against the live [Wallet APIs supported chains](https://www.alchemy.com/docs/wallets/supported-chains) matrix before launch.
 
 ## Integration Notes
 - Define strict sponsorship policies.

--- a/plugins/alchemy/skills/alchemy-api/references/wallets-overview.md
+++ b/plugins/alchemy/skills/alchemy-api/references/wallets-overview.md
@@ -1,10 +1,10 @@
 ---
 id: references/wallets-overview.md
 name: wallets
-description: Integration guide for Alchemy Wallets and smart wallet tooling including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart wallets into your application.
+description: Integration guide for Alchemy Wallet APIs (formerly Smart Wallets) including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart accounts into your application.
 tags: []
 related: []
-updated: 2026-04-15
+updated: 2026-04-22
 metadata:
   author: alchemyplatform
   version: "1.0"
@@ -12,7 +12,7 @@ metadata:
 # Wallets
 
 ## Summary
-High-level integration notes for Alchemy Wallets and smart wallet tooling. This section is intentionally light: enough to integrate without diving into deep wallet infrastructure.
+High-level integration notes for Alchemy **Wallet APIs** (the product formerly branded as "Smart Wallets") and the smart-account tooling around them. This section is intentionally light: enough to integrate without diving into deep wallet infrastructure.
 
 ## References (Recommended Order)
 1. [wallets-details.md](wallets-details.md) - When to use Alchemy wallet tooling.
@@ -39,5 +39,6 @@ High-level integration notes for Alchemy Wallets and smart wallet tooling. This 
 - `agentic-gateway` skill for app code without an API key (x402 or MPP).
 
 ## Official Docs
-- [Smart Wallets](https://www.alchemy.com/docs/wallets)
-- [Wallet APIs Overview](https://www.alchemy.com/docs/get-started)
+- [Wallet APIs](https://www.alchemy.com/docs/wallets)
+- [Wallet APIs Get Started](https://www.alchemy.com/docs/get-started)
+- [Legacy session keys with Wallet APIs](https://www.alchemy.com/docs/wallets/smart-wallets/session-keys/legacy-session-keys) — migration guide for existing session-key setups.

--- a/plugins/alchemy/skills/alchemy-api/references/wallets-smart-wallets.md
+++ b/plugins/alchemy/skills/alchemy-api/references/wallets-smart-wallets.md
@@ -8,12 +8,14 @@ tags:
 related:
   - wallets-bundler.md
   - wallets-gas-manager.md
-updated: 2026-02-05
+updated: 2026-04-22
 ---
 # Smart Wallets
 
+> **Naming note:** Alchemy's product branding has moved from "Smart Wallets" to **Wallet APIs**. This file describes the general *concept* of smart contract accounts / account abstraction — the underlying primitive exposed by Alchemy's Wallet APIs. For the product surface, see `wallets-wallet-apis.md`.
+
 ## Summary
-Smart wallets (account abstraction) enable programmable accounts with features like session keys, batched transactions, and gas sponsorship.
+Smart wallets (account abstraction) are programmable accounts with features like session keys, batched transactions, and gas sponsorship. Alchemy exposes these capabilities through the **Wallet APIs** product.
 
 ## Primary Use Cases
 - Gasless onboarding.
@@ -33,5 +35,5 @@ Smart wallets (account abstraction) enable programmable accounts with features l
 - `wallets-gas-manager.md`
 
 ## Official Docs
-- [Smart Wallets](https://www.alchemy.com/docs/wallets)
+- [Wallet APIs](https://www.alchemy.com/docs/wallets)
 - [Intro to Account Kit](https://www.alchemy.com/docs/wallets/concepts/intro-to-account-kit)

--- a/plugins/alchemy/skills/alchemy-api/references/wallets-wallet-apis.md
+++ b/plugins/alchemy/skills/alchemy-api/references/wallets-wallet-apis.md
@@ -8,7 +8,7 @@ tags:
 related:
   - wallets-account-kit.md
   - operational-auth-and-keys.md
-updated: 2026-04-08
+updated: 2026-04-22
 ---
 # Wallet APIs
 
@@ -17,7 +17,7 @@ High-level wallet APIs enable programmatic wallet operations such as signing, tr
 
 ## Primary Use Cases
 - Server-side transaction preparation.
-- Delegated signing or session-based flows.
+- Delegated signing or session-based flows (including existing session keys — see [Legacy session keys with Wallet APIs](https://www.alchemy.com/docs/wallets/smart-wallets/session-keys/legacy-session-keys) for migrating pre-existing session-key setups).
 - EIP-7702 account delegation and undelegation.
 
 ## EIP-7702 Undelegation
@@ -60,3 +60,5 @@ When users report Wallet API failures, check for these common error patterns:
 ## Official Docs
 - [Account Kit Wallet Client](https://www.alchemy.com/docs/wallets/reference/account-kit/wallet-client)
 - [Wallet API Errors](https://www.alchemy.com/docs/wallets/troubleshooting/wallet-apis-errors)
+- [Legacy session keys with Wallet APIs](https://www.alchemy.com/docs/wallets/smart-wallets/session-keys/legacy-session-keys) — use existing session keys with Wallet APIs.
+- [v5 migration guide](https://www.alchemy.com/docs/wallets/resources/migration-v5)

--- a/skills/alchemy-api/SKILL.md
+++ b/skills/alchemy-api/SKILL.md
@@ -239,7 +239,7 @@ Quick category overview:
 - **Webhooks**: Address Activity, Custom (GraphQL), NFT Activity, Payloads, Signatures
 - **Solana**: JSON-RPC, DAS, Yellowstone gRPC (streaming), Wallets
 - **Sui gRPC**: Objects, Transactions, Balances, Move Packages, Name Service, Subscriptions, Signature Verification
-- **Wallets**: Account Kit, Bundler, Gas Manager, Smart Wallets
+- **Wallets**: Account Kit, Bundler, Gas Manager, Wallet APIs (formerly "Smart Wallets")
 - **Rollups**: L2/L3 deployment overview
 - **Recipes**: 10 end-to-end integration workflows
 - **Operational**: Auth, Rate Limits, Monitoring, Best Practices

--- a/skills/alchemy-api/references/node-overview.md
+++ b/skills/alchemy-api/references/node-overview.md
@@ -4,7 +4,7 @@ name: node-apis
 description: Core JSON-RPC and WebSocket APIs for EVM chains via Alchemy node endpoints, plus Debug/Trace and utility methods. Use when building EVM integrations that need standard RPC calls, real-time subscriptions, enhanced Alchemy methods, or execution-level tracing.
 tags: []
 related: []
-updated: 2026-04-08
+updated: 2026-04-22
 metadata:
   author: alchemyplatform
   version: "1.0"
@@ -22,8 +22,13 @@ Core JSON-RPC and WebSocket APIs for EVM chains via Alchemy node endpoints, plus
 5. [node-debug-api.md](node-debug-api.md) - Debug tracing for transaction simulation and execution insight.
 6. [node-trace-api.md](node-trace-api.md) - Trace-level details for internal calls and state diffs.
 
-## Recently Added Chains
-- **Injective** — Cosmos SDK-based L1 with full EVM compatibility. Supports standard `eth_*` JSON-RPC methods. Use endpoint pattern `injective-mainnet`. See [Injective API Overview](https://www.alchemy.com/docs/chains/injective/injective-api-overview).
+## Recently Added / Updated Chains
+- **Injective** — Cosmos SDK-based L1 with full EVM compatibility. Supports standard `eth_*` JSON-RPC methods. Use endpoint pattern `injective-mainnet`. A few methods (`eth_getBlockReceipts`, `eth_syncing`, `net_listening`) are testnet-only today. Debug namespace (`debug_*`) methods are served by the standalone **Debug API product**, not the chain spec — see [Debug API Quickstart](https://www.alchemy.com/docs/reference/debug-api-quickstart). Overview: [Injective API Overview](https://www.alchemy.com/docs/chains/injective/injective-api-overview).
+- **Gensyn** — mainnet is live. Endpoint `gensyn-mainnet` (chain ID `685689`); `gensyn-testnet` remains available. See the [Gensyn quickstart](https://www.alchemy.com/docs/chains/gensyn/gensyn-api-quickstart).
+- **MegaETH** — supports `eth_getWithdrawalProof` (20 CU). See [Compute Unit Costs](https://www.alchemy.com/docs/reference/compute-unit-costs#megaeth-specific-methods).
+
+## Recently Deprecated Chains
+- **Arbitrum Nova** — deprecated. Nova endpoints are no longer supported; see the [Arbitrum Nova deprecation notice](https://www.alchemy.com/docs/reference/arbitrum-nova/arbitrum-nova-deprecation-notice).
 
 ## How to Use This Skill
 - Start with `node-json-rpc.md` for base connectivity and request patterns.

--- a/skills/alchemy-api/references/node-websocket-subscriptions.md
+++ b/skills/alchemy-api/references/node-websocket-subscriptions.md
@@ -10,13 +10,23 @@ tags:
 related:
   - node-json-rpc.md
   - webhooks-details.md
-updated: 2026-02-23
+updated: 2026-04-22
 ---
 # WebSocket Subscriptions
 
 Real-time blockchain events via WebSocket. No polling required.
 
 **Base URL**: `wss://<network>.g.alchemy.com/v2/$ALCHEMY_API_KEY`
+
+## Billing & Scope Guidance
+Alchemy bills WebSocket subscriptions on the bandwidth they deliver, so broad streams can scale compute unit usage quickly. Keep subscriptions narrow by default:
+
+- Prefer filtered subscriptions (address, topic, or `alchemy_minedTransactions` filters) over network-wide streams.
+- Prefer hash-only payloads when full transaction objects are not required (e.g., `hashesOnly: true` for `alchemy_pendingTransactions` / `alchemy_minedTransactions`).
+- Set [usage limits](https://www.alchemy.com/docs/how-to-set-usage-limits-and-alerts-for-your-account) and alerts before deploying high-volume streams.
+- Broad subscription streams can generate far more ongoing traffic than equivalent HTTP polling, because the server keeps pushing every matching event until you unsubscribe.
+
+See [Compute Unit Costs — Webhooks and Subscription APIs](https://www.alchemy.com/docs/reference/compute-unit-costs#webhooks-and-subscription-apis) for pricing details.
 
 ---
 
@@ -192,7 +202,7 @@ ws.on("message", (data) => {
 
 - Subscriptions are stateful. Handle reconnects and resubscribe after reconnect.
 - You may receive duplicate events on reconnect. De-duplicate by block hash or log index.
-- `newPendingTransactions` is very high volume. Use tight filters if available.
+- `newPendingTransactions` is very high volume. Use tight filters if available, or switch to `alchemy_pendingTransactions` with `addresses` and `hashesOnly: true` to keep bandwidth (and billing) predictable.
 - If WebSockets are unavailable, fall back to HTTP polling with coarse intervals and backoff.
 
 ## Official Docs

--- a/skills/alchemy-api/references/operational-supported-networks.md
+++ b/skills/alchemy-api/references/operational-supported-networks.md
@@ -9,7 +9,7 @@ tags:
 related:
   - node-json-rpc.md
   - solana-rpc.md
-updated: 2026-04-08
+updated: 2026-04-22
 ---
 # Supported Networks
 
@@ -20,6 +20,9 @@ Alchemy supports multiple EVM and Solana networks. Always verify network availab
 - Use chain-specific base URLs (e.g., `eth-mainnet`, `polygon-mainnet`).
 - Use testnets for QA.
 - Not all products are available on every chain.
+
+## Recently Deprecated / Removed
+- **Arbitrum Nova** — deprecated. Nova endpoints (`arbnova-mainnet`, `ARBNOVA_MAINNET`) are no longer supported across Node, Wallets (Bundler, Gas Manager), and related products. See the [Arbitrum Nova deprecation notice](https://www.alchemy.com/docs/reference/arbitrum-nova/arbitrum-nova-deprecation-notice) for migration guidance.
 
 
 ## Spec-Derived Network Enums (Partial)
@@ -32,7 +35,6 @@ ETH_SEPOLIA
 ETH_HOLESKY
 ARB_MAINNET
 ARB_SEPOLIA
-ARBNOVA_MAINNET
 MATIC_MAINNET
 MATIC_MUMBAI
 OPT_MAINNET
@@ -100,7 +102,6 @@ aptos-mainnet
 aptos-testnet
 arb-mainnet
 arb-sepolia
-arbnova-mainnet
 arc-testnet
 astar-mainnet
 avax-fuji

--- a/skills/alchemy-api/references/recipes-subscribe-pending-txs.md
+++ b/skills/alchemy-api/references/recipes-subscribe-pending-txs.md
@@ -8,7 +8,7 @@ tags:
   - recipe
 related:
   - node-websocket-subscriptions.md
-updated: 2026-02-05
+updated: 2026-04-22
 ---
 # Recipe: Subscribe to Pending Transactions
 
@@ -21,8 +21,10 @@ Stream pending transactions in real time and optionally enrich them with transac
 
 ## Steps
 1. Connect to WebSocket endpoint.
-2. Subscribe to `newPendingTransactions`.
+2. Subscribe to `newPendingTransactions` (or `alchemy_pendingTransactions` with address filters for narrower scope).
 3. Optionally call `eth_getTransactionByHash` to enrich data.
+
+> **Billing note:** WebSocket subscriptions are billed on delivered bandwidth. `newPendingTransactions` is extremely high volume on mainnets — prefer `alchemy_pendingTransactions` with `addresses` and `hashesOnly: true`, and set [usage limits](https://www.alchemy.com/docs/how-to-set-usage-limits-and-alerts-for-your-account) before deploying. See `node-websocket-subscriptions.md` for details.
 
 ## Example (TypeScript)
 ```ts

--- a/skills/alchemy-api/references/skill-map.md
+++ b/skills/alchemy-api/references/skill-map.md
@@ -73,12 +73,12 @@ Complete index of all reference files organized by product area. Use the Endpoin
 ## Wallets
 | File | Name | Short Description |
 | --- | --- | --- |
-| `references/wallets-overview.md` | wallets | Integration guide for Alchemy Wallets and smart wallet tooling including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart wallets into your application |
+| `references/wallets-overview.md` | wallets | Integration guide for Alchemy Wallet APIs (formerly "Smart Wallets") including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart accounts into your application |
 | `references/wallets-account-kit.md` | Account Kit | Account Kit is Alchemy's wallet SDK for onboarding users and managing wallet UX. Use it for embedded wallet flows or seamless authentication |
-| `references/wallets-bundler.md` | Bundler | A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets |
+| `references/wallets-bundler.md` | Bundler | A bundler aggregates and submits account abstraction user operations. Use this when integrating smart accounts (Wallet APIs) |
 | `references/wallets-details.md` | Wallets Overview | Alchemy Wallets tooling helps developers embed or integrate wallets with minimal infrastructure. This section is intentionally basic and focuses on integration touchpoints |
 | `references/wallets-gas-manager.md` | Gas Manager | Gas Manager (paymaster) enables gas sponsorship and cost control for smart wallet flows |
-| `references/wallets-smart-wallets.md` | Smart Wallets | Smart wallets (account abstraction) enable programmable accounts with features like session keys, batched transactions, and gas sponsorship |
+| `references/wallets-smart-wallets.md` | Smart Wallets (concept) | Smart wallets (account abstraction) are programmable accounts with features like session keys, batched transactions, and gas sponsorship. Alchemy exposes these via the Wallet APIs product |
 | `references/wallets-solana-notes.md` | Solana Wallet Notes | Solana wallet integration differs from EVM. Use Solana-specific tooling and RPC semantics |
 | `references/wallets-supported-chains.md` | Wallet Supported Chains | Wallet tooling may support a subset of chains compared to raw RPC. Always confirm chain support before launch |
 | `references/wallets-wallet-apis.md` | Wallet APIs | High-level wallet APIs enable programmatic wallet operations such as signing, transaction preparation, or account management. This guide stays minimal and focuses on integration awareness |

--- a/skills/alchemy-api/references/sui-grpc-quickstart.md
+++ b/skills/alchemy-api/references/sui-grpc-quickstart.md
@@ -10,7 +10,7 @@ related:
   - sui-grpc-overview.md
   - sui-grpc-objects-and-ledger.md
   - operational-auth-and-keys.md
-updated: 2026-04-15
+updated: 2026-04-22
 ---
 # Sui gRPC Quickstart
 
@@ -53,6 +53,19 @@ Returns chain name, chain ID, current checkpoint height, and epoch.
 - **Get an object**: `LedgerService/GetObject` with `object_id` and optional `read_mask`.
 - **Get a transaction**: `LedgerService/GetTransaction` with `digest`.
 - **Check balance**: `StateService/GetBalance` with `owner` and `coin_type`.
+
+## `read_mask` format
+`read_mask` is a protobuf [FieldMask](https://protobuf.dev/reference/protobuf/google.protobuf/#field-mask). In JSON (grpcurl, gRPC-web, etc.) encode it as an **object with a `paths` array**, not a comma-separated string:
+
+```bash
+# Correct — FieldMask JSON form
+grpcurl -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -import-path proto -proto sui/rpc/v2/ledger_service.proto \
+  -d '{"object_id": "0x5", "read_mask": {"paths": ["object_id", "version", "digest", "owner"]}}' \
+  sui-mainnet.g.alchemy.com:443 sui.rpc.v2.LedgerService/GetObject
+```
+
+Passing `read_mask` as a bare string (`"object_id,version,..."`) will be rejected.
 
 ## Related Files
 - `sui-grpc-overview.md`

--- a/skills/alchemy-api/references/wallets-bundler.md
+++ b/skills/alchemy-api/references/wallets-bundler.md
@@ -1,19 +1,19 @@
 ---
 id: references/wallets-bundler.md
 name: 'Bundler'
-description: 'A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets. Supports EntryPoint v0.6, v0.7, and v0.8.'
+description: 'A bundler aggregates and submits account abstraction user operations. Use this when integrating smart accounts (Wallet APIs). Supports EntryPoint v0.6, v0.7, and v0.8.'
 tags:
   - alchemy
   - wallets
 related:
   - wallets-smart-wallets.md
   - wallets-gas-manager.md
-updated: 2026-04-08
+updated: 2026-04-22
 ---
 # Bundler
 
 ## Summary
-A bundler aggregates and submits account abstraction user operations. Use this when integrating smart wallets. Powered by Rundler, Alchemy's production-grade ERC-4337 bundler.
+A bundler aggregates and submits account abstraction user operations. Use this when integrating smart accounts via Alchemy Wallet APIs. Powered by Rundler, Alchemy's production-grade ERC-4337 bundler.
 
 ## Supported EntryPoint Versions
 - **v0.6** — original ERC-4337 EntryPoint

--- a/skills/alchemy-api/references/wallets-details.md
+++ b/skills/alchemy-api/references/wallets-details.md
@@ -10,12 +10,14 @@ related:
   - wallets-smart-wallets.md
   - wallets-bundler.md
   - wallets-gas-manager.md
-updated: 2026-02-05
+updated: 2026-04-22
 ---
 # Wallets Overview
 
+> **Naming note:** Alchemy rebranded "Smart Wallets" to **Wallet APIs**. Both terms may still appear in older material; prefer "Wallet APIs" going forward.
+
 ## Summary
-Alchemy Wallets tooling helps developers embed or integrate wallets with minimal infrastructure. This section is intentionally basic and focuses on integration touchpoints.
+Alchemy Wallet APIs help developers embed or integrate wallets with minimal infrastructure. This section is intentionally basic and focuses on integration touchpoints.
 
 ## Primary Use Cases
 - User onboarding with embedded wallets.
@@ -23,7 +25,7 @@ Alchemy Wallets tooling helps developers embed or integrate wallets with minimal
 - Gas sponsorship and transaction bundling.
 
 ## When To Use / Not Use
-- Use when you want a turnkey wallet stack.
+- Use when you want an end-to-end, batteries-included wallet stack (signer → smart account → bundler → paymaster).
 - Avoid if you already have a wallet provider and only need RPC/data.
 
 ## Related Files
@@ -33,4 +35,4 @@ Alchemy Wallets tooling helps developers embed or integrate wallets with minimal
 - `wallets-gas-manager.md`
 
 ## Official Docs
-- [Smart Wallets](https://www.alchemy.com/docs/wallets)
+- [Wallet APIs](https://www.alchemy.com/docs/wallets)

--- a/skills/alchemy-api/references/wallets-gas-manager.md
+++ b/skills/alchemy-api/references/wallets-gas-manager.md
@@ -8,7 +8,7 @@ tags:
 related:
   - wallets-smart-wallets.md
   - wallets-bundler.md
-updated: 2026-04-08
+updated: 2026-04-22
 ---
 # Gas Manager
 
@@ -20,6 +20,9 @@ Gas Manager (paymaster) enables gas sponsorship and cost control for smart walle
 - Sponsoring specific methods or contracts.
 - ERC-20 token gas payments (pay gas with any supported token).
 - BSO (Bundler Sponsorship) policies for EIP-7702 undelegation.
+
+## BSO Chain Support
+Bundler Sponsored Operations (BSOs) are a bundler feature and are supported on **every chain that has both bundler and gas sponsorship support**, with the exception of **MegaETH** (coming soon). Always confirm against the live [Wallet APIs supported chains](https://www.alchemy.com/docs/wallets/supported-chains) matrix before launch.
 
 ## Integration Notes
 - Define strict sponsorship policies.

--- a/skills/alchemy-api/references/wallets-overview.md
+++ b/skills/alchemy-api/references/wallets-overview.md
@@ -1,10 +1,10 @@
 ---
 id: references/wallets-overview.md
 name: wallets
-description: Integration guide for Alchemy Wallets and smart wallet tooling including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart wallets into your application.
+description: Integration guide for Alchemy Wallet APIs (formerly Smart Wallets) including Account Kit, account abstraction, bundler, gas manager, and paymaster. Use when building wallet onboarding flows, sponsoring gas, or integrating smart accounts into your application.
 tags: []
 related: []
-updated: 2026-04-15
+updated: 2026-04-22
 metadata:
   author: alchemyplatform
   version: "1.0"
@@ -12,7 +12,7 @@ metadata:
 # Wallets
 
 ## Summary
-High-level integration notes for Alchemy Wallets and smart wallet tooling. This section is intentionally light: enough to integrate without diving into deep wallet infrastructure.
+High-level integration notes for Alchemy **Wallet APIs** (the product formerly branded as "Smart Wallets") and the smart-account tooling around them. This section is intentionally light: enough to integrate without diving into deep wallet infrastructure.
 
 ## References (Recommended Order)
 1. [wallets-details.md](wallets-details.md) - When to use Alchemy wallet tooling.
@@ -39,5 +39,6 @@ High-level integration notes for Alchemy Wallets and smart wallet tooling. This 
 - `agentic-gateway` skill for app code without an API key (x402 or MPP).
 
 ## Official Docs
-- [Smart Wallets](https://www.alchemy.com/docs/wallets)
-- [Wallet APIs Overview](https://www.alchemy.com/docs/get-started)
+- [Wallet APIs](https://www.alchemy.com/docs/wallets)
+- [Wallet APIs Get Started](https://www.alchemy.com/docs/get-started)
+- [Legacy session keys with Wallet APIs](https://www.alchemy.com/docs/wallets/smart-wallets/session-keys/legacy-session-keys) — migration guide for existing session-key setups.

--- a/skills/alchemy-api/references/wallets-smart-wallets.md
+++ b/skills/alchemy-api/references/wallets-smart-wallets.md
@@ -8,12 +8,14 @@ tags:
 related:
   - wallets-bundler.md
   - wallets-gas-manager.md
-updated: 2026-02-05
+updated: 2026-04-22
 ---
 # Smart Wallets
 
+> **Naming note:** Alchemy's product branding has moved from "Smart Wallets" to **Wallet APIs**. This file describes the general *concept* of smart contract accounts / account abstraction — the underlying primitive exposed by Alchemy's Wallet APIs. For the product surface, see `wallets-wallet-apis.md`.
+
 ## Summary
-Smart wallets (account abstraction) enable programmable accounts with features like session keys, batched transactions, and gas sponsorship.
+Smart wallets (account abstraction) are programmable accounts with features like session keys, batched transactions, and gas sponsorship. Alchemy exposes these capabilities through the **Wallet APIs** product.
 
 ## Primary Use Cases
 - Gasless onboarding.
@@ -33,5 +35,5 @@ Smart wallets (account abstraction) enable programmable accounts with features l
 - `wallets-gas-manager.md`
 
 ## Official Docs
-- [Smart Wallets](https://www.alchemy.com/docs/wallets)
+- [Wallet APIs](https://www.alchemy.com/docs/wallets)
 - [Intro to Account Kit](https://www.alchemy.com/docs/wallets/concepts/intro-to-account-kit)

--- a/skills/alchemy-api/references/wallets-wallet-apis.md
+++ b/skills/alchemy-api/references/wallets-wallet-apis.md
@@ -8,7 +8,7 @@ tags:
 related:
   - wallets-account-kit.md
   - operational-auth-and-keys.md
-updated: 2026-04-08
+updated: 2026-04-22
 ---
 # Wallet APIs
 
@@ -17,7 +17,7 @@ High-level wallet APIs enable programmatic wallet operations such as signing, tr
 
 ## Primary Use Cases
 - Server-side transaction preparation.
-- Delegated signing or session-based flows.
+- Delegated signing or session-based flows (including existing session keys — see [Legacy session keys with Wallet APIs](https://www.alchemy.com/docs/wallets/smart-wallets/session-keys/legacy-session-keys) for migrating pre-existing session-key setups).
 - EIP-7702 account delegation and undelegation.
 
 ## EIP-7702 Undelegation
@@ -60,3 +60,5 @@ When users report Wallet API failures, check for these common error patterns:
 ## Official Docs
 - [Account Kit Wallet Client](https://www.alchemy.com/docs/wallets/reference/account-kit/wallet-client)
 - [Wallet API Errors](https://www.alchemy.com/docs/wallets/troubleshooting/wallet-apis-errors)
+- [Legacy session keys with Wallet APIs](https://www.alchemy.com/docs/wallets/smart-wallets/session-keys/legacy-session-keys) — use existing session keys with Wallet APIs.
+- [v5 migration guide](https://www.alchemy.com/docs/wallets/resources/migration-v5)


### PR DESCRIPTION
Weekly sync of `skills/alchemy-api/references/` (and the mirrored `plugins/alchemy/skills/` bundle) against docs PRs merged in the last 7 days.

## Docs PRs applied

| PR | Change | Skills update |
| --- | --- | --- |
| #1226 — Arbitrum Nova deprecation | Chain removed from node / wallets support | Removed `arbnova-mainnet` / `ARBNOVA_MAINNET` from `operational-supported-networks.md`; added deprecation callouts in `operational-supported-networks.md` and `node-overview.md` |
| #1218 — WebSocket billing callouts | New billing guidance in docs | Added a **Billing & Scope Guidance** section to `node-websocket-subscriptions.md`; added a billing note to `recipes-subscribe-pending-txs.md` |
| #1219 — Safer websocket examples | Prefer `hashesOnly: true` + address filters | Tightened the `newPendingTransactions` guidance in both files above |
| #1245 — Clarify BSO chain support | BSOs everywhere bundler + gas sponsorship intersect, except MegaETH | Added a **BSO Chain Support** section to `wallets-gas-manager.md` |
| #1223 — Rebrand Smart Wallets → Wallet APIs | Product-level terminology shift | Updated `wallets-overview.md`, `wallets-details.md`, `wallets-bundler.md`, `wallets-smart-wallets.md` (now framed as the *concept* page), `skill-map.md`, and `alchemy-api/SKILL.md` product list to prefer "Wallet APIs"; kept the smart-account concept intact |
| #1247 — Legacy session keys with Wallet APIs (new page) | New guide for migrating existing session keys | Linked from `wallets-wallet-apis.md` and `wallets-overview.md` |
| #1239 — Gensyn mainnet launch | `gensyn-mainnet`, chain ID 685689 | Added to `node-overview.md` (Recently Added / Updated Chains) |
| #1237 — MegaETH `eth_getWithdrawalProof` CU cost | New method / 20 CU | Noted in `node-overview.md` |
| #1241 — Injective overview refresh | Debug methods live in Debug API product; a few methods testnet-only | Updated Injective entry in `node-overview.md` |
| #1227 — Sui gRPC `read_mask` format fix | `read_mask` must be a FieldMask JSON object | Added a **`read_mask` format** section with correct grpcurl example to `sui-grpc-quickstart.md` |

## Docs PRs reviewed but no skills change needed

- **#1232, #1229** — copy polish and signer-agnostic / viem / Privy / 7702 clarifications in the wallets authentication overview. Skills references don't promote specific signers at this granularity, and the concepts are already covered where relevant.
- **#1251** — Turnkey recommendation removal from overview pages. No "Turnkey" (the company) references exist anywhere in the skills repo (`grep -rn 'Turnkey' skills/ plugins/` is empty), so nothing to remove. The word "turnkey" in `wallets-details.md` was a generic "batteries-included" phrasing; rephrased to avoid the brand collision anyway.
- **#1233** — Alchemy CLI page and Build-with-AI overview rework. The `alchemy-cli` and `alchemy-mcp` skills already exist and are cross-linked from wallets / node references; no further skill updates needed.
- **#1221** — PAYG Usage Limit FAQ. The skills references already point users to usage limits (now reinforced via the websocket billing additions above); the FAQ itself is not mirrored in skills.

## Mechanical

- Edited files under `skills/alchemy-api/references/` and then re-ran `plugins/alchemy/scripts/sync_from_catalog.py` so `plugins/alchemy/skills/` stays byte-identical.
- All touched files have their `updated:` front-matter bumped to `2026-04-22`.