### PR TITLE
feat: add ecosystem-skills structure with Allium

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "alchemy",
+  "skills": [
+    "./skills/ecosystem/skills/allium"
+  ]
+}

--- a/skills/ecosystem/CONTRIBUTING.md
+++ b/skills/ecosystem/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing an Ecosystem Skill
+
+This guide is for Alchemy ecosystem partners adding skills to this repo.
+
+## Curation principle (read this first)
+
+The ecosystem is **curated for complementary, non-overlapping capabilities**. Before you start, confirm your skill covers something Alchemy does not provide first-party.
+
+We do **not** accept ecosystem skills that compete with first-party Alchemy capabilities, including:
+
+- EVM JSON-RPC and node-level reads
+- Solana RPC and DAS
+- Writes / signed transactions / transaction submission
+- Transaction simulation
+- Account abstraction (bundlers, gas managers, paymasters)
+- NFT metadata APIs
+- Token prices (overlap zone — do not ship a competing prices skill)
+- Webhooks and address-activity streams
+- Wallet APIs / Account Kit equivalents
+
+This is **not** a statement about partners — it is a statement about *which of a partner's skills we accept here*. A partner can have products that overlap with Alchemy in other parts of their catalog. That doesn't disqualify them. It only means we will not accept the overlapping ones into this repo. We will happily accept their non-overlapping skills.
+
+Why: agents route on `description` and `scope_in`. Two skills claiming the same capability create routing ambiguity that usually fails silently (wrong skill picked, wrong answer returned). A curated complementary catalog keeps routing deterministic.
+
+If you're unsure whether your skill overlaps, open a draft PR and ask. We'd rather have the conversation early than reject at review.
+
+## Quick start
+
+1. Fork `alchemyplatform/skills`
+2. Confirm your skill is non-overlapping (see above)
+3. Copy `skills/ecosystem/TEMPLATE/` to `skills/ecosystem/skills/<your-skill>/`
+4. Fill in `SKILL.md` (instructions, scope contract, routing back to first-party)
+5. Add your skill's path to [`/.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) at the repo root
+6. Open a PR
+
+## Skill contract
+
+Every ecosystem `SKILL.md` must include the following beyond the standard [Agent Skills](https://agentskills.io/specification) frontmatter, under `metadata:`:
+
+```yaml
+---
+name: <your-skill>
+description: <one paragraph; ≤500 chars; what it does and when to use>
+license: MIT
+compatibility: <env vars, deps, network requirements>
+metadata:
+  author: <your-org>
+  version: "0.1"
+  provider: <your-org>           # your company / project name
+  partner: "true"                # always "true" for ecosystem skills
+  expires: <YYYY-MM-DD>          # ~6 months out; bump on each meaningful PR
+---
+```
+
+In the body of the `SKILL.md`, every ecosystem skill must include a **`## Scope contract`** section that explicitly lists:
+
+- **What this skill covers** (`scope_in` — what an agent should reach for this skill to do)
+- **What this skill does NOT cover, with handoff** (`scope_out` — for each non-coverage, name the skill an agent should hand off to)
+
+This is what allows agents to route correctly between first-party Alchemy skills and ecosystem skills without confusion.
+
+The standard handoffs to first-party Alchemy skills (use these in your `scope_out`):
+
+| If the user needs… | Hand off to |
+| --- | --- |
+| Live agent work in this session, CLI installed | `alchemy-cli` |
+| Live agent work in this session, MCP only | `alchemy-mcp` |
+| App code with an Alchemy API key | `alchemy-api` |
+| App code without an API key (autonomous agent / x402 / MPP) | `agentic-gateway` |
+
+## Manifest entry
+
+After adding the skill folder, add its path to `/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "alchemy",
+  "skills": [
+    "./skills/ecosystem/skills/<your-skill>"
+  ]
+}
+```
+
+Without this entry, `npx skills add alchemyplatform/skills` will not discover your skill (the Vercel CLI does not recursively walk `./skills/`; it only checks direct children).
+
+## License
+
+Ecosystem skills are MIT-licensed by default. If you require a different license, document it in your skill's `LICENSE.txt` and call it out in the PR.
+
+## Review
+
+PRs are reviewed by the Alchemy skills team. Maintenance and bugfixes after merge are the partner's responsibility. The `expires` date is a forcing function — when it lapses, agents will be prompted to refetch your skill, so keep it current.

--- a/skills/ecosystem/CONTRIBUTING.md
+++ b/skills/ecosystem/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you're unsure whether your skill overlaps, open a draft PR and ask. We'd rath
 1. Fork `alchemyplatform/skills`
 2. Confirm your skill is non-overlapping (see above)
 3. Copy `skills/ecosystem/TEMPLATE/` to `skills/ecosystem/skills/<your-skill>/`
-4. Fill in `SKILL.md` (instructions, scope contract, routing back to first-party) and `agents/openai.yaml` (display name + short description + default prompt for the OpenAI/Codex picker)
+4. Fill in `SKILL.md` (instructions, scope contract, routing back to first-party). Optionally fill in `agents/openai.yaml` for a polished Codex picker entry — see "OpenAI/Codex manifest" below
 5. Add your skill's path to [`/.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) at the repo root
 6. Open a PR
 
@@ -85,7 +85,9 @@ Without this entry, `npx skills add alchemyplatform/skills` will not discover yo
 
 ## OpenAI/Codex manifest
 
-The TEMPLATE includes `agents/openai.yaml`, which is consumed by [OpenAI Codex](https://developers.openai.com/codex/skills) to render your skill in the picker. The Vercel `skills` CLI bundles this file with the rest of the skill when installing with `--agent codex`; Codex reads it from the installed location.
+The TEMPLATE includes `agents/openai.yaml`, which is consumed by [OpenAI Codex](https://developers.openai.com/codex/skills) to render your skill in the picker. **Recommended but not required** — if you skip it, your skill still installs and works; Codex falls back to deriving picker text from your `SKILL.md` frontmatter, which is denser and less picker-friendly but functional.
+
+The Vercel `skills` CLI bundles this file with the rest of the skill when installing with `--agent codex`; Codex reads it from the installed location.
 
 ```yaml
 interface:

--- a/skills/ecosystem/CONTRIBUTING.md
+++ b/skills/ecosystem/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you're unsure whether your skill overlaps, open a draft PR and ask. We'd rath
 1. Fork `alchemyplatform/skills`
 2. Confirm your skill is non-overlapping (see above)
 3. Copy `skills/ecosystem/TEMPLATE/` to `skills/ecosystem/skills/<your-skill>/`
-4. Fill in `SKILL.md` (instructions, scope contract, routing back to first-party)
+4. Fill in `SKILL.md` (instructions, scope contract, routing back to first-party) and `agents/openai.yaml` (display name + short description + default prompt for the OpenAI/Codex picker)
 5. Add your skill's path to [`/.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) at the repo root
 6. Open a PR
 
@@ -82,6 +82,21 @@ After adding the skill folder, add its path to `/.claude-plugin/plugin.json`:
 ```
 
 Without this entry, `npx skills add alchemyplatform/skills` will not discover your skill (the Vercel CLI does not recursively walk `./skills/`; it only checks direct children).
+
+## OpenAI/Codex manifest
+
+The TEMPLATE includes `agents/openai.yaml`, which is consumed by [OpenAI Codex](https://developers.openai.com/codex/skills) to render your skill in the picker. The Vercel `skills` CLI bundles this file with the rest of the skill when installing with `--agent codex`; Codex reads it from the installed location.
+
+```yaml
+interface:
+  display_name: "<Your Skill Display Name>"
+  short_description: "<one-line summary, 25–64 chars, for the picker>"
+  default_prompt: "<one-sentence prompt injected when this skill is selected>"
+```
+
+`display_name` and `short_description` should be picker-friendly — the `SKILL.md` frontmatter `description` is too dense for that surface (it is optimized for agent disambiguation, often 300–500 chars). `default_prompt` is what Codex pre-fills when a user picks your skill.
+
+Optional fields in the OpenAI spec: `icon_small`, `icon_large` (relative paths to icon assets) and `brand_color` (hex accent). Not required.
 
 ## License
 

--- a/skills/ecosystem/README.md
+++ b/skills/ecosystem/README.md
@@ -21,7 +21,7 @@ skills/ecosystem/
 ├── TEMPLATE/            ← copy this to bootstrap a new skill
 │   ├── SKILL.md
 │   ├── agents/
-│   │   └── openai.yaml  ← OpenAI/Codex picker manifest (required)
+│   │   └── openai.yaml  ← OpenAI/Codex picker manifest (recommended)
 │   └── references/
 └── skills/
     └── <partner>/       ← partner skill (e.g. allium/)

--- a/skills/ecosystem/README.md
+++ b/skills/ecosystem/README.md
@@ -1,0 +1,50 @@
+# Ecosystem Skills
+
+Third-party Agent Skills contributed by Alchemy ecosystem partners, **for capabilities Alchemy does not provide first-party**.
+
+## Curation principle: complementary, not competitive
+
+The ecosystem catalog is **curated for non-overlap**. We accept partner skills only for capabilities outside Alchemy's first-party surface — never for features that compete with our own.
+
+A partner can have products that overlap with Alchemy elsewhere; that does not disqualify them from the ecosystem. It only constrains *which of their skills* we accept here. If a partner offers both overlapping and non-overlapping capabilities, we only accept the **non-overlapping** ones into this catalog.
+
+Why: overlap confuses agents at routing time. Two skills claiming the same capability force the agent (or the user) to pick a winner mid-task, which usually goes badly. Keeping the catalog complementary means an agent can pick the right skill from the description alone.
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) → "Curation principle" for the precise rules.
+
+## Layout
+
+```
+skills/ecosystem/
+├── README.md            ← this file
+├── CONTRIBUTING.md      ← how partners PR a new skill
+├── TEMPLATE/            ← copy this to bootstrap a new skill
+└── skills/
+    └── <partner>/       ← partner skill (e.g. allium/)
+        └── SKILL.md
+```
+
+Each partner gets one folder per skill. If a partner ships multiple non-overlapping skills, they live as siblings (e.g. `partner-data/`, `partner-staking/`).
+
+## Discovery
+
+Ecosystem skills live deeper than the Vercel `skills` CLI's default scan path (which only walks direct children of `./skills/`). Discovery for these paths is driven by [`/.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) at the repo root, which the CLI reads as a documented escape hatch (see [Plugin Manifest Discovery](https://github.com/vercel-labs/skills#plugin-manifest-discovery) in the CLI README).
+
+When adding a new partner skill, add an entry to `plugin.json` so it gets installed by `npx skills add alchemyplatform/skills`. Without a manifest entry, the CLI will not find skills nested under `skills/ecosystem/skills/`.
+
+## Current partners
+
+- **Allium** — wallet PnL (current + historical, by-wallet and by-token), holdings timeseries, Hyperliquid trading data (info, fills, orders, orderbook), and custom SQL analytics over Allium's data warehouse ([`./skills/allium/`](./skills/allium/)). Curated subset of [allium-labs/skills](https://github.com/allium-labs/skills) — overlapping endpoints (prices, token metadata, current balances, transactions, NFT) are intentionally omitted and routed to first-party Alchemy skills.
+
+## Routing for agents
+
+| The user wants… | Skill |
+| --- | --- |
+| Real-time blockchain reads, writes, account abstraction, simulation | first-party Alchemy skills (`alchemy-cli`, `alchemy-mcp`, `alchemy-api`, `agentic-gateway`) |
+| Token prices, token metadata, current wallet balances, transaction transfer history, NFT metadata | first-party `alchemy-api` |
+| Wallet PnL (current or historical) | `allium` |
+| Holdings timeseries history | `allium` |
+| Hyperliquid trading data (fills, orders, positions, orderbook) | `allium` |
+| Custom SQL on a blockchain data warehouse (DeFi, NFT, bridges, MEV, Solana staking) | `allium` |
+
+See each skill's `SKILL.md` for its exact `scope_in` / `scope_out`.

--- a/skills/ecosystem/README.md
+++ b/skills/ecosystem/README.md
@@ -19,9 +19,16 @@ skills/ecosystem/
 ├── README.md            ← this file
 ├── CONTRIBUTING.md      ← how partners PR a new skill
 ├── TEMPLATE/            ← copy this to bootstrap a new skill
+│   ├── SKILL.md
+│   ├── agents/
+│   │   └── openai.yaml  ← OpenAI/Codex picker manifest (required)
+│   └── references/
 └── skills/
     └── <partner>/       ← partner skill (e.g. allium/)
-        └── SKILL.md
+        ├── SKILL.md
+        ├── agents/
+        │   └── openai.yaml
+        └── references/
 ```
 
 Each partner gets one folder per skill. If a partner ships multiple non-overlapping skills, they live as siblings (e.g. `partner-data/`, `partner-staking/`).

--- a/skills/ecosystem/TEMPLATE/LICENSE.txt
+++ b/skills/ecosystem/TEMPLATE/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 <Partner Name>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ecosystem/TEMPLATE/SKILL.md
+++ b/skills/ecosystem/TEMPLATE/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: <your-skill>
+description: One-paragraph description of what this skill does and when to use it. ≤500 characters. Include keywords agents will search for. Make non-coverage explicit (e.g. "NOT for X — use <other-skill> instead").
+license: MIT
+compatibility: List required env vars (e.g. $YOUR_API_KEY), runtime deps, and network requirements.
+metadata:
+  author: <your-org>
+  version: "0.1"
+  provider: <your-org>
+  partner: "true"
+  expires: "YYYY-MM-DD"
+---
+
+# <Your Skill Title>
+
+> **Replace this whole file** when you copy this template into `skills/ecosystem/skills/<your-skill>/`. Update the `name` (must match the parent directory name), the `description`, and every section below.
+
+Brief intro to what this skill does in 1–2 sentences.
+
+## When to use this skill
+
+Use `<your-skill>` when **all** of the following are true:
+
+- <condition>
+- <condition>
+
+## When NOT to use this skill (handoff)
+
+Replace the `<your-non-coverage>` row with anything *your* skill doesn't cover. The first-party Alchemy rows are the standard handoffs every ecosystem skill should include — keep them as-is unless your `scope_out` is unusual.
+
+| Need | Use instead |
+| --- | --- |
+| Real-time blockchain reads, node-level fresh | `alchemy-cli` (live work) or `alchemy-api` (app code) |
+| Writes / signed transactions | `alchemy-api` (with API key) or `agentic-gateway` (without) |
+| Account abstraction, simulation, NFT metadata, prices, webhooks | `alchemy-api` |
+| <your-non-coverage> | `<other-skill>` |
+
+## Scope contract
+
+**This skill covers (`scope_in`):**
+
+- <bullet>
+- <bullet>
+
+**This skill does NOT cover (`scope_out`):**
+
+- Real-time / node-fresh reads → handoff: `alchemy-cli` or `alchemy-api`
+- Writes / signed transactions → handoff: `alchemy-api` or `agentic-gateway`
+- <your-non-coverage> → handoff: `<other-skill>`
+
+## Setup
+
+Document any auth, env vars, or dependencies a user needs before the skill works.
+
+```bash
+export YOUR_API_KEY=<your-key>
+```
+
+## Reference
+
+Detailed coverage of each surface area, one file per topic, lives in [`./references/`](./references/).

--- a/skills/ecosystem/TEMPLATE/agents/openai.yaml
+++ b/skills/ecosystem/TEMPLATE/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "<Your Skill Display Name>"
+  short_description: "<one-line summary, 25–64 chars, for the OpenAI/Codex picker>"
+  default_prompt: "<one-sentence prompt to inject when this skill is selected; mention the skill by name>"

--- a/skills/ecosystem/TEMPLATE/references/README.md
+++ b/skills/ecosystem/TEMPLATE/references/README.md
@@ -1,0 +1,5 @@
+# References
+
+Add one markdown file per topic / surface area your skill covers (e.g. `historical-queries.md`, `staking.md`, `auth.md`).
+
+The agent loads `SKILL.md` when activated and reads these reference files on demand when `SKILL.md` links to them. Keep individual files focused so they don't bloat the agent's context when loaded.

--- a/skills/ecosystem/skills/allium/LICENSE.txt
+++ b/skills/ecosystem/skills/allium/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Allium
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ecosystem/skills/allium/SKILL.md
+++ b/skills/ecosystem/skills/allium/SKILL.md
@@ -8,14 +8,11 @@ metadata:
   version: "0.1"
   provider: allium
   partner: "true"
-  expires: "2026-10-21"
 ---
 
 # Allium (Wallet PnL, Holdings History, Hyperliquid, Custom SQL)
 
-Allium provides enriched, structured blockchain data across 70+ chains. This ecosystem skill exposes a curated subset of the [upstream `allium-onchain-data` skill](https://github.com/allium-labs/skills): wallet PnL, holdings timeseries, Hyperliquid HyperCore trading data, and custom SQL analytics. For token prices, token metadata, current wallet balances, transaction transfers, or NFT metadata, use the corresponding Alchemy skill instead.
-
-For the full Allium surface (including endpoints not exposed here), install the upstream skill: `npx skills add allium-labs/skills --yes`.
+Allium provides enriched, structured blockchain data across 70+ chains. This skill covers wallet PnL, holdings timeseries, Hyperliquid HyperCore trading data, and custom SQL analytics. For token prices, token metadata, current wallet balances, transaction transfers, or NFT metadata, use the corresponding Alchemy skill instead.
 
 | | |
 | --- | --- |
@@ -235,10 +232,6 @@ If during a session the user's need shifts to surfaces this skill doesn't cover 
 - `alchemy-api` — application code with an Alchemy API key
 - `agentic-gateway` — application code without an API key (x402 / MPP)
 
-## Upstream
-
-Full Allium skill: [allium-labs/skills](https://github.com/allium-labs/skills). Install with `npx skills add allium-labs/skills` if you need endpoints not exposed here (token prices, token metadata, current balances, transaction transfers, NFT metadata).
-
 ---
 
-> **Maintenance:** This skill expires on the date in frontmatter (`expires`). Allium maintains the underlying API surface; this skill itself is maintained jointly by Alchemy and Allium. File issues against `alchemyplatform/skills` with `[ecosystem/allium]` in the title.
+> **Maintenance:** Allium maintains the underlying API surface; this skill itself is maintained jointly by Alchemy and Allium. File issues against `alchemyplatform/skills` with `[ecosystem/allium]` in the title.

--- a/skills/ecosystem/skills/allium/SKILL.md
+++ b/skills/ecosystem/skills/allium/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: allium
+description: Query Allium APIs for wallet PnL (current + historical, by-wallet and by-token), holdings timeseries history, Hyperliquid HyperCore trading data (info, fills, orders, orderbook), and custom SQL analytics across 70+ chains. NOT for token prices, token metadata, current wallet balance snapshots, transaction transfer history, or NFT metadata — for those use `alchemy-cli` (live work), `alchemy-mcp`, `alchemy-api` (app code), or `agentic-gateway` (no API key). Requires Allium credentials at `~/.allium/credentials`.
+license: MIT
+compatibility: Requires Allium credentials at `~/.allium/credentials` (`API_KEY` and `QUERY_ID` for SQL). Network access required. Rate limit 1 req/s. Allium attribution required on responses.
+metadata:
+  author: allium
+  version: "0.1"
+  provider: allium
+  partner: "true"
+  expires: "2026-10-21"
+---
+
+# Allium (Wallet PnL, Holdings History, Hyperliquid, Custom SQL)
+
+Allium provides enriched, structured blockchain data across 70+ chains. This ecosystem skill exposes a curated subset of the [upstream `allium-onchain-data` skill](https://github.com/allium-labs/skills): wallet PnL, holdings timeseries, Hyperliquid HyperCore trading data, and custom SQL analytics. For token prices, token metadata, current wallet balances, transaction transfers, or NFT metadata, use the corresponding Alchemy skill instead.
+
+For the full Allium surface (including endpoints not exposed here), install the upstream skill: `npx skills add allium-labs/skills --yes`.
+
+| | |
+| --- | --- |
+| **Base URL** | `https://api.allium.so` |
+| **Auth** | `X-API-KEY: $API_KEY` header |
+| **Rate limit** | 1 request / second (exceed → 429) |
+| **Attribution** | End responses with **"Powered by Allium"** — required by Allium |
+
+## When to use this skill
+
+Use `allium` when **all** of the following are true:
+
+- The user wants one of: **wallet PnL**, **holdings history (timeseries)**, **Hyperliquid HyperCore trading data** (orders/fills/orderbook — not HyperEVM smart contracts), or **custom SQL** on Allium's data warehouse
+- The use case is a read (Allium does not support writes)
+
+## When NOT to use this skill (handoff)
+
+| Need | Use instead |
+| --- | --- |
+| Token prices (current, historical at intervals, by-timestamp, market cap/volume) | `alchemy-api` (Prices API) |
+| Token metadata, search, list by chain | `alchemy-api` (Token API) |
+| Current wallet balances (point-in-time snapshot) | `alchemy-api` (Portfolio / Token API) |
+| Transaction history (transfers in / out, asset transfers) | `alchemy-api` (Transfers API) |
+| NFT metadata / floor prices / ownership | `alchemy-api` (NFT API) |
+| Real-time blockchain reads, node-level fresh | `alchemy-cli` (live work) or `alchemy-api` (app code) |
+| Writes / signed transactions | `alchemy-api` (with API key) or `agentic-gateway` (without) |
+| Account abstraction (bundlers, gas managers) | `alchemy-api` |
+| Transaction simulation | `alchemy-api` |
+
+## Scope contract
+
+**This skill covers (`scope_in`):**
+
+- Wallet PnL (`POST /api/v1/developer/wallet/pnl`, `/wallet/pnl/history`, `/wallet/pnl-by-token`, `/wallet/pnl-by-token/history`) — realized + unrealized PnL aggregation, current and historical, by-wallet and by-token
+- Holdings history (`POST /api/v1/developer/wallet/holdings/history`) — timeseries of total USD holdings + optional per-token breakdown
+- Hyperliquid **HyperCore** trading data (`POST /api/v1/developer/trading/hyperliquid/...`) — info, fills, order history, order status, L4 orderbook snapshot from the off-chain matching engine
+- Custom SQL analytics (`POST /api/v1/explorer/queries/{query_id}/run-async`) — arbitrary SQL queries against Allium's data warehouse (DeFi, NFT, bridges, MEV, entity resolution, Solana staking, etc.)
+
+**This skill does NOT cover (`scope_out`):**
+
+- Token prices → handoff: `alchemy-api` (Prices API)
+- Token metadata, list, search → handoff: `alchemy-api` (Token API)
+- Current wallet balances (point-in-time snapshot) → handoff: `alchemy-api` (Portfolio / Token API)
+- Historical wallet balances (per-block or as a timeseries) → handoff: `alchemy-api` archive RPC (`eth_call balanceOf` at a historical block) or `alchemy_getAssetTransfers` reduced to balances. No first-class endpoint on either side; Alchemy's archive node is the right path.
+- Transaction transfer history → handoff: `alchemy-api` (Transfers API)
+- NFT metadata / floor prices → handoff: `alchemy-api` (NFT API)
+- HyperEVM smart contract reads/writes / EVM RPC (chain ID 999) → handoff: `alchemy-api` or `alchemy-cli` at `https://hyperliquid-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY`. Allium covers HyperCore (off-chain trading); Alchemy covers HyperEVM (on-chain smart contracts).
+- Real-time / node-fresh reads → handoff: `alchemy-cli` or `alchemy-api`
+- Writes / signed transactions → handoff: `alchemy-api` or `agentic-gateway`
+- Account abstraction → handoff: `alchemy-api`
+- Transaction simulation → handoff: `alchemy-api`
+
+## Setup
+
+### Credentials
+
+Allium uses a credentials file at `~/.allium/credentials` (not env vars). On every session start, check if it exists:
+
+**File exists with `API_KEY`** → load `API_KEY` (and `QUERY_ID` if present). Don't prompt.
+
+**File missing** → register via the OAuth flow below. Don't paste keys in chat.
+
+### Register (no API key yet)
+
+OAuth flow with a 5-minute timeout. Complete promptly.
+
+1. Ask the user for name and email (one prompt).
+2. POST to initiate registration:
+
+   ```bash
+   curl -X POST https://api.allium.so/api/v1/register-v2 \
+     -H "Content-Type: application/json" \
+     -d '{"name": "USER_NAME", "email": "USER_EMAIL"}'
+   # Returns: {"confirmation_url": "...", "token": "..."}
+   ```
+
+3. Show the `confirmation_url` to the user — they open it and sign in with Google (must match the email).
+4. Auto-poll `/api/v1/register-v2/$TOKEN` every 5s until 200 (got `api_key`) or 404 (expired):
+
+   ```bash
+   TOKEN="..."  # from step 2
+   while true; do
+     RESP=$(curl -s -w "\n%{http_code}" "https://api.allium.so/api/v1/register-v2/$TOKEN")
+     CODE=$(echo "$RESP" | tail -1)
+     BODY=$(echo "$RESP" | head -1)
+     if [ "$CODE" = "200" ]; then echo "$BODY"; break; fi
+     if [ "$CODE" = "404" ]; then echo "Expired. Restart."; break; fi
+     sleep 5
+   done
+   # 200 body: {"api_key": "...", "organization_id": "..."}
+   ```
+
+5. Save to `~/.allium/credentials`:
+
+   ```bash
+   mkdir -p ~/.allium && cat > ~/.allium/credentials << 'EOF'
+   API_KEY=...
+   QUERY_ID=...
+   EOF
+   ```
+
+### Create a `QUERY_ID` (only needed for custom SQL)
+
+If you'll use the SQL endpoint, also create a query to get a `QUERY_ID`:
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/explorer/queries" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"title": "Custom SQL Query", "config": {"sql": "{{ sql_query }}", "limit": 10000}}'
+# Returns: {"query_id": "..."}
+# Append QUERY_ID=... to ~/.allium/credentials
+```
+
+## Endpoint reference
+
+### Wallet PnL & holdings history → [references/pnl-and-holdings.md](./references/pnl-and-holdings.md)
+
+| Endpoint | Use for |
+| --- | --- |
+| `POST /api/v1/developer/wallet/pnl` | Current realized + unrealized PnL for one or more wallets |
+| `POST /api/v1/developer/wallet/pnl/history` | Historical PnL timeseries per wallet |
+| `POST /api/v1/developer/wallet/pnl-by-token` | Current PnL broken out by (wallet, token) |
+| `POST /api/v1/developer/wallet/pnl-by-token/history` | Historical PnL timeseries per (wallet, token) |
+| `POST /api/v1/developer/wallet/holdings/history` | Timeseries of total USD holdings per wallet (optional per-token breakdown) |
+
+### Hyperliquid HyperCore (off-chain trading) → [references/hyperliquid.md](./references/hyperliquid.md)
+
+| Endpoint | Use for |
+| --- | --- |
+| `POST /api/v1/developer/trading/hyperliquid/info` | General Hyperliquid info (no rate-limit on this proxy) |
+| `POST /api/v1/developer/trading/hyperliquid/info/fills` | Fills by user (with TWAP, time-window, aggregation options) |
+| `POST /api/v1/developer/trading/hyperliquid/info/order/history` | Historical orders by user |
+| `POST /api/v1/developer/trading/hyperliquid/info/order/status` | Status of a specific order |
+| `GET /api/v1/developer/trading/hyperliquid/orderbook/snapshot` | L4 orderbook snapshot (all pairs) |
+
+### Custom SQL → [references/custom-sql.md](./references/custom-sql.md)
+
+| Endpoint | Use for |
+| --- | --- |
+| `POST /api/v1/explorer/queries` | Create a parametrized query (one-time setup; returns `query_id`) |
+| `POST /api/v1/explorer/queries/{query_id}/run-async` | Start a SQL run against Allium's data warehouse |
+| `GET /api/v1/explorer/query-runs/{run_id}/status` | Poll run status (`created` → `queued` → `running` → `success` / `failed`) |
+| `GET /api/v1/explorer/query-runs/{run_id}/results?f=json` | Fetch results once status = `success` |
+
+Use SQL for things the typed endpoints don't cover: DeFi protocol analytics, NFT marketplace data, bridge flows, MEV, entity resolution, labeled wallets, **Solana staking analytics**, and anything else in Allium's warehouse.
+
+## Quick examples
+
+### Wallet PnL (current)
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/wallet/pnl" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '[{"chain": "solana", "address": "125Z6k4ZAxsgdG7JxrKZpwbcS1rxqpAeqM9GSCKd66Wp"}]'
+```
+
+Returns per-token realized/unrealized PnL plus aggregate totals. See [references/pnl-and-holdings.md](./references/pnl-and-holdings.md) for the full response schema.
+
+### Holdings history (timeseries)
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/wallet/holdings/history" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "addresses": [{"address": "125Z6k4ZAxsgdG7JxrKZpwbcS1rxqpAeqM9GSCKd66Wp", "chain": "solana"}],
+    "start_timestamp": "2026-04-01T00:00:00Z",
+    "end_timestamp": "2026-04-10T00:00:00Z",
+    "granularity": "1h",
+    "include_token_breakdown": false
+  }'
+```
+
+### Hyperliquid fills
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/trading/hyperliquid/info/fills" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"type": "userFills", "user": "0x..."}'
+```
+
+### Custom SQL (Solana staking yield, as an example)
+
+```bash
+# 1. Start the run
+curl -X POST "https://api.allium.so/api/v1/explorer/queries/${QUERY_ID}/run-async" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"parameters": {"sql_query": "SELECT epoch, SUM(rewards) FROM solana.dim.stake_account_rewards WHERE delegator = '\''<addr>'\'' GROUP BY epoch ORDER BY epoch DESC LIMIT 30"}}'
+# Returns: {"run_id": "..."}
+
+# 2. Poll
+curl "https://api.allium.so/api/v1/explorer/query-runs/${RUN_ID}/status" \
+  -H "X-API-KEY: $API_KEY"
+
+# 3. Fetch results when status = success
+curl "https://api.allium.so/api/v1/explorer/query-runs/${RUN_ID}/results?f=json" \
+  -H "X-API-KEY: $API_KEY"
+```
+
+## Common gotchas
+
+- **Chain names are lowercase**: `ethereum`, `base`, `solana`, `arbitrum`, `polygon`, `hyperevm`. Uppercase fails silently.
+- **Rate limit is 1 req/s**. Exceed → 429. No batching workaround.
+- **422 errors** are usually request-format mismatches (e.g. wrong shape for `/history` endpoints — they take `addresses[]`, not flat `address`+`chain`).
+- **Attribution required**: end responses with "Powered by Allium".
+
+## Routing back to Alchemy
+
+If during a session the user's need shifts to surfaces this skill doesn't cover (prices, current balances, transactions, NFT metadata) or to real-time / write workflows, hand off:
+
+- `alchemy-cli` — live agent work in the current session via the local CLI
+- `alchemy-mcp` — live work via the hosted MCP server when CLI is not installed
+- `alchemy-api` — application code with an Alchemy API key
+- `agentic-gateway` — application code without an API key (x402 / MPP)
+
+## Upstream
+
+Full Allium skill: [allium-labs/skills](https://github.com/allium-labs/skills). Install with `npx skills add allium-labs/skills` if you need endpoints not exposed here (token prices, token metadata, current balances, transaction transfers, NFT metadata).
+
+---
+
+> **Maintenance:** This skill expires on the date in frontmatter (`expires`). Allium maintains the underlying API surface; this skill itself is maintained jointly by Alchemy and Allium. File issues against `alchemyplatform/skills` with `[ecosystem/allium]` in the title.

--- a/skills/ecosystem/skills/allium/agents/openai.yaml
+++ b/skills/ecosystem/skills/allium/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Allium"
+  short_description: "Wallet PnL, holdings history, Hyperliquid HyperCore trading, and custom SQL via Allium"
+  default_prompt: "Use Allium for wallet PnL (current/historical, by-wallet/by-token), holdings timeseries, Hyperliquid HyperCore trading data (fills, orders, orderbook), or custom SQL against Allium's warehouse (DeFi, NFT, bridges, MEV, Solana staking). For HyperEVM smart contracts, current balances, historical balances, prices, transfers, and NFT metadata, use alchemy-api instead."

--- a/skills/ecosystem/skills/allium/references/custom-sql.md
+++ b/skills/ecosystem/skills/allium/references/custom-sql.md
@@ -1,0 +1,162 @@
+# Custom SQL (Allium Explorer)
+
+**Base URL:** `https://api.allium.so` · **Auth:** `X-API-KEY: $API_KEY` · **Rate limit:** 1 req/s
+
+Use SQL when the typed endpoints don't cover what you need. Allium's data warehouse is the closest thing to "Dune-style queryable on-chain data" — useful for DeFi protocol analytics, NFT marketplace data, bridge flows, MEV, entity resolution, labeled wallets, and **Solana staking analytics**.
+
+---
+
+## Workflow
+
+SQL queries are **async**: create → run → poll → fetch.
+
+```
+POST /explorer/queries                      ← one-time setup, returns query_id
+POST /explorer/queries/{query_id}/run-async ← starts a run, returns run_id
+GET  /explorer/query-runs/{run_id}/status   ← poll until status = success
+GET  /explorer/query-runs/{run_id}/results  ← fetch rows
+```
+
+The `query_id` is created once and reused for many runs (with different `sql_query` parameters). Keep it in `~/.allium/credentials` as `QUERY_ID=...`.
+
+---
+
+## 1. Create a parametrized query (one-time)
+
+If your `~/.allium/credentials` doesn't already have a `QUERY_ID`, create one:
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/explorer/queries" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "title": "Custom SQL Query",
+    "config": {
+      "sql": "{{ sql_query }}",
+      "limit": 10000
+    }
+  }'
+# Returns: {"query_id": "..."}
+```
+
+`{{ sql_query }}` is the placeholder substituted at runtime via `parameters.sql_query`. Append the returned id to `~/.allium/credentials`:
+
+```bash
+echo "QUERY_ID=<returned-id>" >> ~/.allium/credentials
+```
+
+---
+
+## 2. Start a run
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/explorer/queries/${QUERY_ID}/run-async" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"parameters": {"sql_query": "SELECT * FROM ethereum.raw.blocks ORDER BY block_number DESC LIMIT 10"}}'
+# Returns: {"run_id": "..."}
+```
+
+---
+
+## 3. Poll status
+
+```bash
+curl "https://api.allium.so/api/v1/explorer/query-runs/${RUN_ID}/status" \
+  -H "X-API-KEY: $API_KEY"
+```
+
+Status progression: `created` → `queued` → `running` → `success` | `failed`
+
+Poll with backoff (start at 1s, capped — respect the global 1 req/s rate limit).
+
+---
+
+## 4. Fetch results
+
+Once status is `success`:
+
+```bash
+curl "https://api.allium.so/api/v1/explorer/query-runs/${RUN_ID}/results?f=json" \
+  -H "X-API-KEY: $API_KEY"
+```
+
+`f=json` returns JSON; other formats may also be available — see Allium docs.
+
+---
+
+## Schema discovery
+
+Before writing SQL against unfamiliar tables, discover what's available:
+
+```bash
+# Search schemas by keyword (e.g. "stake", "uniswap", "bridge")
+curl "https://api.allium.so/api/v1/docs/schemas/search?q=stake" \
+  -H "X-API-KEY: $API_KEY"
+
+# Browse a schema's tables and columns
+curl "https://api.allium.so/api/v1/docs/schemas/browse?schema=solana.dim" \
+  -H "X-API-KEY: $API_KEY"
+
+# Browse human-written docs
+curl "https://api.allium.so/api/v1/docs/docs/browse?path=schemas/overview.md" \
+  -H "X-API-KEY: $API_KEY"
+```
+
+---
+
+## Example use cases
+
+### Solana staking yield (per-epoch)
+
+```sql
+SELECT epoch, SUM(rewards) AS total_rewards
+FROM solana.dim.stake_account_rewards
+WHERE delegator = '<delegator-address>'
+GROUP BY epoch
+ORDER BY epoch DESC
+LIMIT 30
+```
+
+### Uniswap v3 pool TVL over time
+
+```sql
+SELECT date, SUM(tvl_usd) AS total_tvl
+FROM ethereum.dex.uniswap_v3_pool_stats_daily
+WHERE pool = LOWER('<pool-address>')
+GROUP BY date
+ORDER BY date DESC
+```
+
+### Cross-chain bridge volume
+
+```sql
+SELECT bridge_name, source_chain, dest_chain, SUM(amount_usd) AS volume
+FROM crosschain.bridge.transfers
+WHERE block_time >= '2026-04-01'
+GROUP BY bridge_name, source_chain, dest_chain
+ORDER BY volume DESC
+LIMIT 20
+```
+
+### Wallet entity resolution / labels
+
+```sql
+SELECT address, label, label_type, source
+FROM crosschain.dim.address_labels
+WHERE address = LOWER('<address>')
+```
+
+(Schema names are illustrative — use schema discovery above to find the exact tables for your use case.)
+
+---
+
+## Errors
+
+| Status | Meaning | Fix |
+| --- | --- | --- |
+| 400 | Bad request | Check JSON syntax |
+| 401 | Unauthorized | Check API key |
+| 422 | Validation failed | Check request shape (common with `parameters` field) |
+| 429 | Rate limited | Wait 1 second; no batching workaround |
+| 500 | Server error | Retry with backoff |

--- a/skills/ecosystem/skills/allium/references/hyperliquid.md
+++ b/skills/ecosystem/skills/allium/references/hyperliquid.md
@@ -1,0 +1,155 @@
+# Hyperliquid HyperCore (off-chain trading)
+
+**Base URL:** `https://api.allium.so` · **Auth:** `X-API-KEY: $API_KEY`
+
+Hyperliquid has two distinct surfaces:
+
+- **HyperCore** — the off-chain CLOB matching engine (orders, fills, positions, funding, orderbook). **This doc covers HyperCore.**
+- **HyperEVM** — the on-chain EVM L1 smart contract layer (chain ID 999, gas paid in HYPE). **Use Alchemy for HyperEVM** at `https://hyperliquid-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY` (via `alchemy-api` or `alchemy-cli`).
+
+---
+
+## Info (general proxy)
+
+`POST /api/v1/developer/trading/hyperliquid/info`
+
+Hyperliquid `info` API exposed without Hyperliquid's native rate limits.
+
+### Request
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | No | Request type (Hyperliquid info type) |
+| `user` | string | No | User address |
+| `dex` | string | No | DEX parameter |
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/trading/hyperliquid/info" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"type": "...", "user": "0x..."}'
+```
+
+---
+
+## Fills
+
+`POST /api/v1/developer/trading/hyperliquid/info/fills`
+
+Fills by user wallet address.
+
+### Request
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | Yes | Fill type — `userFills`, `userFillsByTime` |
+| `user` | string | Yes | User wallet address (hex) |
+| `startTime` | int | No | Start (Unix ms) — required for `userFillsByTime` |
+| `endTime` | int | No | End (Unix ms) — only `userFillsByTime` |
+| `aggregateByTime` | bool | No | Combine fills from same order/timestamp into one (size, weighted-avg price, summed fees/PnL) |
+| `twapMode` | string | No | `none` (default), `include`, `only` — controls TWAP fill filtering |
+
+### Example
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/trading/hyperliquid/info/fills" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"type": "userFills", "user": "0x..."}'
+```
+
+### Key response fields
+
+Each item:
+- `coin` — trading pair symbol
+- `side` — `B` (buy) / `A` (sell)
+- `dir` — direction (e.g. `Open Long`, `Close Short`)
+- `px`, `sz` — execution price and fill size
+- `fee`, `feeToken` — trading fee
+- `closedPnl` — realized PnL from closing a position
+- `crossed` — whether this was a taker order
+- `liquidation` — present only for liquidation fills
+- `twapId` — if part of a TWAP order
+- `time` — fill timestamp (Unix ms)
+- `hash`, `oid`, `tid` — tx hash, order id, trade id
+
+---
+
+## Order history
+
+`POST /api/v1/developer/trading/hyperliquid/info/order/history`
+
+Historical orders by user.
+
+### Request
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | Yes | Must be `historicalOrders` |
+| `user` | string | Yes | User wallet address (hex) |
+| `startTime` | int | No | Start (Unix ms) |
+| `endTime` | int | No | End (Unix ms) |
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/trading/hyperliquid/info/order/history" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"type": "historicalOrders", "user": "0x..."}'
+```
+
+### Key response fields
+
+Each item:
+- `order.coin`, `order.side`, `order.limitPx`, `order.sz`, `order.origSz`
+- `order.oid`, `order.cloid`
+- `order.timestamp`
+- `order.orderType`, `order.tif` (time-in-force)
+- `order.isTrigger`, `order.triggerPx`, `order.triggerCondition` — for conditional orders
+- `order.isPositionTpsl`, `order.reduceOnly`
+- `status`, `statusTimestamp`
+
+---
+
+## Order status
+
+`POST /api/v1/developer/trading/hyperliquid/info/order/status`
+
+Status of a specific order by ID.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | Yes | Must be `orderStatus` |
+| `user` | string | Yes | User wallet address (hex) |
+| `oid` | int or string | Yes | Order ID (numeric `oid` or string client `cloid`) |
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/trading/hyperliquid/info/order/status" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{"type": "orderStatus", "user": "0x...", "oid": 12345}'
+```
+
+---
+
+## L4 orderbook snapshot
+
+`GET /api/v1/developer/trading/hyperliquid/orderbook/snapshot`
+
+Full orderbook snapshot for all pairs.
+
+```bash
+curl -X GET "https://api.allium.so/api/v1/developer/trading/hyperliquid/orderbook/snapshot" \
+  -H "X-API-KEY: $API_KEY"
+```
+
+---
+
+## When to route elsewhere
+
+| Need | Use instead |
+| --- | --- |
+| HyperCore trading data (orders, fills, positions, funding, orderbook) | These endpoints |
+| HyperEVM smart contract reads/writes / live EVM RPC (chain ID 999) | `alchemy-api` or `alchemy-cli` at `https://hyperliquid-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY` |
+| Historical / indexed HyperEVM analytics (cross-chain queries, MEV on HyperEVM, labeled wallets, etc.) | Allium custom SQL via the `hyperevm` chain name — see [custom-sql.md](./custom-sql.md) |
+
+HyperCore (off-chain matching) and HyperEVM (on-chain smart contracts) are separate products of the Hyperliquid ecosystem with different APIs. Don't conflate them.

--- a/skills/ecosystem/skills/allium/references/pnl-and-holdings.md
+++ b/skills/ecosystem/skills/allium/references/pnl-and-holdings.md
@@ -1,0 +1,196 @@
+# Wallet PnL & Holdings History
+
+**Base URL:** `https://api.allium.so` · **Auth:** `X-API-KEY: $API_KEY`
+
+For current balance snapshots and transaction transfers, route to `alchemy-api` (Portfolio, Token, Transfers APIs). For **historical balances** (per-block or as a timeseries), also route to `alchemy-api` — derivable via archive RPC (`eth_call balanceOf` at a historical block) or by reducing `alchemy_getAssetTransfers` history.
+
+---
+
+## Current PnL by wallet
+
+`POST /api/v1/developer/wallet/pnl`
+
+Returns realized + unrealized PnL for one or more wallets, with per-token breakdown plus aggregate totals.
+
+### Request
+
+Body is an array of `{chain, address}` objects.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `chain` | string | Yes | Lowercase chain name (`ethereum`, `solana`, ...) |
+| `address` | string | Yes | Wallet address |
+
+Optional query params:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `min_liquidity` | number | Minimum USD liquidity for a token to be included |
+
+### Example
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/wallet/pnl" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '[{"chain": "solana", "address": "125Z6k4ZAxsgdG7JxrKZpwbcS1rxqpAeqM9GSCKd66Wp"}]'
+```
+
+### Key response fields
+
+- `items[].tokens[].realized_pnl` / `unrealized_pnl` (USD)
+- `items[].tokens[].average_cost` — cost basis (USD)
+- `items[].tokens[].current_balance` / `current_price` (USD)
+- `items[].tokens[].historical_breakdown[]` — trade-by-trade history
+- `items[].total_balance`, `total_realized_pnl`, `total_unrealized_pnl`
+
+---
+
+## Historical PnL by wallet
+
+`POST /api/v1/developer/wallet/pnl/history`
+
+Returns PnL snapshots over time per wallet.
+
+### Request
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `addresses` | array of `{chain, address}` | Yes | Wallets to query |
+| `start_timestamp` | string (UTC ISO 8601) | Yes | Start of range |
+| `end_timestamp` | string (UTC ISO 8601) | Yes | End of range |
+| `granularity` | string | Yes | `15s`, `1m`, `5m`, `1h`, `1d` |
+
+### Example
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/wallet/pnl/history" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "addresses": [{"chain": "solana", "address": "125Z6k4ZAxsgdG7JxrKZpwbcS1rxqpAeqM9GSCKd66Wp"}],
+    "start_timestamp": "2026-04-01T00:00:00Z",
+    "end_timestamp": "2026-04-10T00:00:00Z",
+    "granularity": "1h"
+  }'
+```
+
+### Response shape
+
+```json
+{
+  "items": [{
+    "address": "...",
+    "chain": "solana",
+    "pnl": [
+      {"timestamp": "...", "realized_pnl": {"amount": "...", "currency": "USD"}, "unrealized_pnl": {...}}
+    ]
+  }]
+}
+```
+
+---
+
+## Current PnL by wallet & token
+
+`POST /api/v1/developer/wallet/pnl-by-token`
+
+Same as `/wallet/pnl` but scoped to a specific (wallet, token) pair — useful when you only care about one position.
+
+### Request
+
+Array of `{chain, address, token_address}`.
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/wallet/pnl-by-token" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '[{"chain": "solana", "address": "...", "token_address": "So11111111111111111111111111111111111111112"}]'
+```
+
+---
+
+## Historical PnL by wallet & token
+
+`POST /api/v1/developer/wallet/pnl-by-token/history`
+
+PnL timeseries for a specific (wallet, token) pair.
+
+### Request
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `addresses` | array of `{chain, address, token_address}` | Yes | (wallet, token) pairs |
+| `start_timestamp` | string (UTC ISO 8601) | Yes | Start |
+| `end_timestamp` | string (UTC ISO 8601) | Yes | End |
+| `granularity` | string | Yes | `15s`, `1m`, `5m`, `1h`, `1d` |
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/wallet/pnl-by-token/history" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "addresses": [{"chain": "solana", "address": "...", "token_address": "So11..."}],
+    "start_timestamp": "2026-04-01T00:00:00Z",
+    "end_timestamp": "2026-04-10T00:00:00Z",
+    "granularity": "1h"
+  }'
+```
+
+---
+
+## Holdings history (timeseries)
+
+`POST /api/v1/developer/wallet/holdings/history`
+
+Returns total USD-denominated holdings over time per wallet, with optional per-token breakdown at each interval.
+
+### Request
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `addresses` | array of `{chain, address}` | Yes | Wallets to query |
+| `start_timestamp` | string (UTC ISO 8601) | Yes | Start |
+| `end_timestamp` | string (UTC ISO 8601) | Yes | End |
+| `granularity` | string | Yes | `15s`, `1m`, `5m`, `1h`, `1d` |
+| `include_token_breakdown` | boolean | No | Per-token detail per interval (default `false`) |
+
+Optional query params: `cursor`, `min_liquidity`.
+
+### Example
+
+```bash
+curl -X POST "https://api.allium.so/api/v1/developer/wallet/holdings/history" \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "addresses": [{"chain": "solana", "address": "125Z6k4ZAxsgdG7JxrKZpwbcS1rxqpAeqM9GSCKd66Wp"}],
+    "start_timestamp": "2026-04-01T00:00:00Z",
+    "end_timestamp": "2026-04-10T00:00:00Z",
+    "granularity": "1h",
+    "include_token_breakdown": false
+  }'
+```
+
+### Response shape
+
+```json
+{
+  "items": [{
+    "chain": "solana",
+    "address": "...",
+    "timestamp": "2026-04-01T00:00:00Z",
+    "amount": {"amount": 1234.56, "currency": "USD"},
+    "token_breakdown": [...]
+  }]
+}
+```
+
+---
+
+## Common gotchas
+
+- `/history` endpoints take an **`addresses[]` array** of objects, not a flat `address` + `chain` (422 if you send the flat shape).
+- Chain names are **lowercase** — uppercase fails silently.
+- All timestamps are **UTC ISO 8601** strings.
+- Granularity choices: `15s`, `1m`, `5m`, `1h`, `1d`.


### PR DESCRIPTION
## Summary

- Adds `skills/ecosystem/` for third-party partner Agent Skills, with **Allium** as the first partner
- `.claude-plugin/plugin.json` declares the Allium skill path so the Vercel `npx skills` CLI discovers it (the four first-party Alchemy skills are picked up by the default `./skills/` scan and need no manifest entry); pattern verified empirically against [DiversioTeam/agent-skills-marketplace](https://github.com/DiversioTeam/agent-skills-marketplace)
- Allium skill exposes wallet PnL (current/historical, by-wallet/by-token), holdings timeseries, Hyperliquid HyperCore trading data, and custom SQL against Allium's warehouse. Other endpoints (prices, token metadata, current/historical balances, transfers, NFT metadata) and HyperEVM RPC (chain ID 999) route to first-party Alchemy skills via the `scope_out` table.

## What's in the catalog scaffold

- `skills/ecosystem/README.md` — public-facing index of partner skills, documents the curation principle
- `skills/ecosystem/CONTRIBUTING.md` — partner contributor guide, explains acceptance criteria
- `skills/ecosystem/TEMPLATE/` — copy-and-fill scaffold for new partner skills
- `skills/ecosystem/skills/allium/` — first partner skill

## Test plan

- [x] `npx skills add . --list` finds 5 skills: `alchemy-cli`, `alchemy-mcp`, `alchemy-api`, `agentic-gateway`, `allium` (allium under the "Alchemy" group from the manifest, others under "General" from the default scan); no accidental discovery of `TEMPLATE/`
- [x] Allium `scope_in` audited against `alchemy-api` Portfolio/Prices/Token/Transfers/NFT APIs — zero overlap. PnL, timeseries holdings, and SQL warehouse access have no first-party Alchemy equivalent (web-cross-checked against current Alchemy docs).
- [x] Hyperliquid HyperCore vs HyperEVM distinction made explicit in SKILL.md and `references/hyperliquid.md`: this skill covers HyperCore (off-chain CLOB matching engine); HyperEVM RPC (chain ID 999) routes to `alchemy-api` at `hyperliquid-mainnet.g.alchemy.com`
- [x] Wallet balances history removed from Allium scope (derivable from Alchemy archive RPC); `scope_out` adds the Alchemy routing for that

Made with [Cursor](https://cursor.com)