### PR TITLE
[Writer] Weekly skills update — 2026-04-30

### DIFF
--- a/plugins/alchemy/skills/alchemy-api/references/node-websocket-subscriptions.md
+++ b/plugins/alchemy/skills/alchemy-api/references/node-websocket-subscriptions.md
@@ -1,20 +1,22 @@
 ---
 id: references/node-websocket-subscriptions.md
 name: 'WebSocket Subscriptions'
-description: 'Use WebSockets for real-time blockchain events without polling. Best for pending transactions, new blocks, and logs.'
+description: 'Use WebSockets for real-time blockchain events without polling. EVM uses eth_subscribe; Solana uses native *Subscribe / *Unsubscribe PubSub methods.'
 tags:
   - alchemy
   - node-apis
   - evm
+  - solana
   - rpc
 related:
   - node-json-rpc.md
+  - solana-rpc.md
   - webhooks-details.md
-updated: 2026-04-22
+updated: 2026-04-30
 ---
 # WebSocket Subscriptions
 
-Real-time blockchain events via WebSocket. No polling required.
+Real-time blockchain events via WebSocket. No polling required. EVM chains use `eth_subscribe` / `eth_unsubscribe`; Solana uses native `*Subscribe` / `*Unsubscribe` PubSub methods (see [Solana PubSub Subscriptions](#solana-pubsub-subscriptions)).
 
 **Base URL**: `wss://<network>.g.alchemy.com/v2/$ALCHEMY_API_KEY`
 
@@ -198,6 +200,64 @@ ws.on("message", (data) => {
 
 ---
 
+## Solana PubSub Subscriptions
+
+Solana exposes a separate PubSub WebSocket API. Use the Solana base URL:
+
+```text
+wss://solana-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY
+wss://solana-devnet.g.alchemy.com/v2/$ALCHEMY_API_KEY
+```
+
+Do **not** use `eth_subscribe` on Solana. Each method is named `<event>Subscribe` and is paired with a matching `<event>Unsubscribe`. A successful subscribe returns a numeric subscription id; pass that id to the unsubscribe call to cancel the stream. Most methods accept an optional `commitment` parameter (defaults to `finalized`).
+
+### Methods
+
+| Category | Method | Purpose |
+|----------|--------|---------|
+| Accounts | `accountSubscribe` | Notify when one account's lamports or data change. |
+| Accounts | `programSubscribe` | Notify on accounts owned by a program. Scope with `dataSize` / `memcmp` filters; unfiltered streams can be very high bandwidth. |
+| Transactions | `logsSubscribe` | Notify on transaction log messages matching a filter (`all`, `allWithVotes`, or `{ mentions: [pubkey] }`). |
+| Transactions | `signatureSubscribe` | Notify on status changes for a single transaction signature. Auto-completes once the signature reaches the requested commitment. |
+| Cluster | `slotSubscribe` | Notify when the validator processes a new slot. |
+| Cluster | `rootSubscribe` | Notify when the validator sets a new root slot. |
+
+Notifications arrive as JSON-RPC messages with method-specific names (`accountNotification`, `programNotification`, `logsNotification`, `signatureNotification`, `slotNotification`, `rootNotification`). The payload is in `params.result` with the matching `params.subscription` id.
+
+### Example (`@solana/web3.js`)
+
+```ts
+import { Connection, PublicKey } from "@solana/web3.js";
+
+const connection = new Connection(
+  `https://solana-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+  {
+    wsEndpoint: `wss://solana-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+    commitment: "confirmed",
+  }
+);
+
+const pubkey = new PublicKey("So11111111111111111111111111111111111111112");
+const subId = await connection.onAccountChange(pubkey, (accountInfo, ctx) => {
+  console.log("slot:", ctx.slot, "lamports:", accountInfo.lamports);
+});
+
+// Later: await connection.removeAccountChangeListener(subId);
+```
+
+### Solana subscription billing
+
+Solana WebSocket subscriptions are billed by **bandwidth** (per byte delivered), not per-message. Broad streams — especially unfiltered `programSubscribe` and `logsSubscribe` `all` / `allWithVotes` — can scale CU usage quickly.
+
+- Always scope with `mentions` / `mentionsAccountOrProgram` / `dataSize` / `memcmp` where supported.
+- Keep payloads small: prefer `encoding: "base64"` over `jsonParsed`, and `transactionDetails: "signatures"` when you don't need full tx data.
+- Set [usage limits](https://www.alchemy.com/docs/how-to-set-usage-limits-and-alerts-for-your-account) before deploying broad subscriptions in production.
+- See [Compute Unit Costs — Solana WebSocket Subscriptions](https://www.alchemy.com/docs/reference/compute-unit-costs#solana-websocket-subscriptions) for the per-byte CU rate.
+
+For higher-throughput, structured Solana streaming (account / slot / transaction streams with server-side filters), consider Yellowstone gRPC instead — see the `solana-grpc-*` references.
+
+---
+
 ## Notes
 
 - Subscriptions are stateful. Handle reconnects and resubscribe after reconnect.
@@ -208,3 +268,5 @@ ws.on("message", (data) => {
 ## Official Docs
 - [Subscription API Overview](https://www.alchemy.com/docs/reference/subscription-api)
 - [eth_subscribe](https://www.alchemy.com/docs/chains/ethereum/ethereum-api-endpoints/eth-subscribe)
+- [Solana Subscription API Endpoints](https://www.alchemy.com/docs/reference/solana-subscription-api-endpoints)
+- [accountSubscribe](https://www.alchemy.com/docs/reference/account-subscribe), [programSubscribe](https://www.alchemy.com/docs/reference/program-subscribe), [logsSubscribe](https://www.alchemy.com/docs/reference/logs-subscribe), [signatureSubscribe](https://www.alchemy.com/docs/reference/signature-subscribe), [slotSubscribe](https://www.alchemy.com/docs/reference/slot-subscribe), [rootSubscribe](https://www.alchemy.com/docs/reference/root-subscribe)

--- a/plugins/alchemy/skills/alchemy-api/references/operational-supported-networks.md
+++ b/plugins/alchemy/skills/alchemy-api/references/operational-supported-networks.md
@@ -9,7 +9,7 @@ tags:
 related:
   - node-json-rpc.md
   - solana-rpc.md
-updated: 2026-04-22
+updated: 2026-04-30
 ---
 # Supported Networks
 
@@ -195,6 +195,7 @@ polynomial-sepolia
 race-mainnet
 race-sepolia
 risa-testnet
+rise-mainnet
 rise-testnet
 ronin-mainnet
 ronin-saigon

--- a/plugins/alchemy/skills/alchemy-api/references/skill-map.md
+++ b/plugins/alchemy/skills/alchemy-api/references/skill-map.md
@@ -15,7 +15,7 @@ Complete index of all reference files organized by product area. Use the Endpoin
 | `references/node-json-rpc.md` | JSON-RPC (EVM) | Use Alchemy's EVM JSON-RPC endpoints for standard blockchain reads and writes (e.g., `eth_call`, `eth_getLogs`, `eth_sendRawTransaction`). This is the baseline for any EVM integration |
 | `references/node-trace-api.md` | Trace API | Trace APIs expose internal call data and state changes for transactions and blocks. Useful for analytics and auditing |
 | `references/node-utility-api.md` | Utility API | Convenience RPC methods that reduce round trips for common tasks like bulk transaction receipt retrieval |
-| `references/node-websocket-subscriptions.md` | WebSocket Subscriptions | Use WebSockets for real-time blockchain events without polling. Best for pending transactions, new blocks, and logs |
+| `references/node-websocket-subscriptions.md` | WebSocket Subscriptions | Use WebSockets for real-time blockchain events without polling. EVM uses `eth_subscribe`; Solana uses native `*Subscribe` / `*Unsubscribe` PubSub methods (`accountSubscribe`, `programSubscribe`, `logsSubscribe`, `signatureSubscribe`, `slotSubscribe`, `rootSubscribe`) |
 
 ## Data
 | File | Name | Short Description |
@@ -43,8 +43,8 @@ Complete index of all reference files organized by product area. Use the Endpoin
 ## Solana
 | File | Name | Short Description |
 | --- | --- | --- |
-| `references/solana-overview.md` | solana | Solana-specific APIs including standard JSON-RPC, Digital Asset Standard (DAS) for NFTs and compressed assets, and wallet integration. Use when building Solana applications that need RPC access, NFT/asset queries, or Solana wallet tooling. For high-throughput streaming, see the yellowstone-grpc skill |
-| `references/solana-das-api.md` | Solana DAS (Digital Asset Standard) API | DAS provides normalized access to Solana NFT and compressed asset data |
+| `references/solana-overview.md` | solana | Solana-specific APIs including standard JSON-RPC, Digital Asset Standard (DAS) for NFTs and Bubblegum compressed NFTs, the Photon indexer for ZK Compression, WebSocket PubSub subscriptions, and wallet integration. Use when building Solana applications that need RPC access, NFT/asset queries, ZK-compressed state, real-time event streams, or Solana wallet tooling. For high-throughput streaming, see the yellowstone-grpc skill |
+| `references/solana-das-api.md` | Solana DAS (Digital Asset Standard) API | DAS provides normalized access to Solana NFT and Bubblegum compressed NFT (cNFT) data. For ZK Compression accounts/tokens, use the Photon API instead (see solana-overview) |
 | `references/solana-grpc-best-practices.md` | Yellowstone Best Practices | Practical guidance to keep Yellowstone consumers reliable and efficient |
 | `references/solana-grpc-details.md` | Yellowstone gRPC Overview | Yellowstone gRPC provides high-throughput Solana data streams for blocks, transactions, accounts, and slots. Use this for real-time indexing at scale |
 | `references/solana-grpc-examples.md` | Yellowstone Examples | Minimal examples for connecting and subscribing. The exact client depends on your gRPC stack |

--- a/plugins/alchemy/skills/alchemy-api/references/solana-overview.md
+++ b/plugins/alchemy/skills/alchemy-api/references/solana-overview.md
@@ -1,10 +1,10 @@
 ---
 id: references/solana-overview.md
 name: solana
-description: Solana-specific APIs including standard JSON-RPC, Digital Asset Standard (DAS) for NFTs and compressed assets, and wallet integration. Use when building Solana applications that need RPC access, NFT/asset queries, or Solana wallet tooling. For high-throughput streaming, see the yellowstone-grpc skill.
+description: Solana-specific APIs including standard JSON-RPC, Digital Asset Standard (DAS) for NFTs and Bubblegum compressed NFTs, the Photon indexer for ZK Compression accounts/tokens, WebSocket PubSub subscriptions, and wallet integration. Use when building Solana applications that need RPC access, NFT/asset queries, ZK-compressed state, real-time event streams, or Solana wallet tooling. For high-throughput streaming, see the yellowstone-grpc skill.
 tags: []
 related: []
-updated: 2026-02-14
+updated: 2026-04-30
 metadata:
   author: alchemyplatform
   version: "1.0"
@@ -16,8 +16,14 @@ Solana-specific APIs and streaming endpoints, including DAS (Digital Asset Stand
 
 ## References (Recommended Order)
 1. [solana-rpc.md](solana-rpc.md) - Standard Solana JSON-RPC usage patterns.
-2. [solana-das-api.md](solana-das-api.md) - DAS endpoints for assets and metadata.
+2. [solana-das-api.md](solana-das-api.md) - DAS endpoints for NFTs and Bubblegum compressed NFTs.
 3. [solana-wallets.md](solana-wallets.md) - Solana wallet integration notes.
+4. [node-websocket-subscriptions.md](node-websocket-subscriptions.md) - Solana PubSub subscriptions (`accountSubscribe`, `programSubscribe`, `logsSubscribe`, `signatureSubscribe`, `slotSubscribe`, `rootSubscribe`).
+
+## Photon API (ZK Compression)
+Alchemy serves the [Photon](https://github.com/helius-labs/photon) indexer on the standard Solana endpoints. Photon exposes [ZK Compression](https://www.zkcompression.com/) state — compressed accounts, compressed token balances, and compression-related signatures — via JSON-RPC. Methods include `getCompressedAccount`, `getCompressedAccountsByOwner`, `getCompressedTokenAccountsByOwner`, `getCompressedTokenBalancesByOwnerV2`, `getValidityProof` / `getValidityProofV2`, and the `getCompressionSignaturesFor*` family. Use the same Solana endpoint URL (`https://solana-mainnet.g.alchemy.com/v2/<API_KEY>` or `solana-devnet`).
+
+Note: ZK Compression (Photon) and Bubblegum compressed NFTs (DAS) are **different** primitives. Photon is for arbitrary ZK-compressed accounts/tokens; DAS `getAsset` / `getAssetProof` is for Bubblegum cNFTs.
 
 ## Cross-References
 - `yellowstone-grpc` skill for high-throughput streaming (accounts/transactions/blocks).
@@ -30,3 +36,5 @@ Solana-specific APIs and streaming endpoints, including DAS (Digital Asset Stand
 ## Official Docs
 - [Solana API Quickstart](https://www.alchemy.com/docs/reference/solana-api-quickstart)
 - [DAS APIs for Solana](https://www.alchemy.com/docs/reference/alchemy-das-apis-for-solana)
+- [Photon APIs for Solana ZK Compression](https://www.alchemy.com/docs/reference/alchemy-photon-apis-for-solana)
+- [Solana Subscription API Endpoints](https://www.alchemy.com/docs/reference/solana-subscription-api-endpoints)

--- a/skills/alchemy-api/references/node-websocket-subscriptions.md
+++ b/skills/alchemy-api/references/node-websocket-subscriptions.md
@@ -1,20 +1,22 @@
 ---
 id: references/node-websocket-subscriptions.md
 name: 'WebSocket Subscriptions'
-description: 'Use WebSockets for real-time blockchain events without polling. Best for pending transactions, new blocks, and logs.'
+description: 'Use WebSockets for real-time blockchain events without polling. EVM uses eth_subscribe; Solana uses native *Subscribe / *Unsubscribe PubSub methods.'
 tags:
   - alchemy
   - node-apis
   - evm
+  - solana
   - rpc
 related:
   - node-json-rpc.md
+  - solana-rpc.md
   - webhooks-details.md
-updated: 2026-04-22
+updated: 2026-04-30
 ---
 # WebSocket Subscriptions
 
-Real-time blockchain events via WebSocket. No polling required.
+Real-time blockchain events via WebSocket. No polling required. EVM chains use `eth_subscribe` / `eth_unsubscribe`; Solana uses native `*Subscribe` / `*Unsubscribe` PubSub methods (see [Solana PubSub Subscriptions](#solana-pubsub-subscriptions)).
 
 **Base URL**: `wss://<network>.g.alchemy.com/v2/$ALCHEMY_API_KEY`
 
@@ -198,6 +200,64 @@ ws.on("message", (data) => {
 
 ---
 
+## Solana PubSub Subscriptions
+
+Solana exposes a separate PubSub WebSocket API. Use the Solana base URL:
+
+```text
+wss://solana-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY
+wss://solana-devnet.g.alchemy.com/v2/$ALCHEMY_API_KEY
+```
+
+Do **not** use `eth_subscribe` on Solana. Each method is named `<event>Subscribe` and is paired with a matching `<event>Unsubscribe`. A successful subscribe returns a numeric subscription id; pass that id to the unsubscribe call to cancel the stream. Most methods accept an optional `commitment` parameter (defaults to `finalized`).
+
+### Methods
+
+| Category | Method | Purpose |
+|----------|--------|---------|
+| Accounts | `accountSubscribe` | Notify when one account's lamports or data change. |
+| Accounts | `programSubscribe` | Notify on accounts owned by a program. Scope with `dataSize` / `memcmp` filters; unfiltered streams can be very high bandwidth. |
+| Transactions | `logsSubscribe` | Notify on transaction log messages matching a filter (`all`, `allWithVotes`, or `{ mentions: [pubkey] }`). |
+| Transactions | `signatureSubscribe` | Notify on status changes for a single transaction signature. Auto-completes once the signature reaches the requested commitment. |
+| Cluster | `slotSubscribe` | Notify when the validator processes a new slot. |
+| Cluster | `rootSubscribe` | Notify when the validator sets a new root slot. |
+
+Notifications arrive as JSON-RPC messages with method-specific names (`accountNotification`, `programNotification`, `logsNotification`, `signatureNotification`, `slotNotification`, `rootNotification`). The payload is in `params.result` with the matching `params.subscription` id.
+
+### Example (`@solana/web3.js`)
+
+```ts
+import { Connection, PublicKey } from "@solana/web3.js";
+
+const connection = new Connection(
+  `https://solana-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+  {
+    wsEndpoint: `wss://solana-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+    commitment: "confirmed",
+  }
+);
+
+const pubkey = new PublicKey("So11111111111111111111111111111111111111112");
+const subId = await connection.onAccountChange(pubkey, (accountInfo, ctx) => {
+  console.log("slot:", ctx.slot, "lamports:", accountInfo.lamports);
+});
+
+// Later: await connection.removeAccountChangeListener(subId);
+```
+
+### Solana subscription billing
+
+Solana WebSocket subscriptions are billed by **bandwidth** (per byte delivered), not per-message. Broad streams — especially unfiltered `programSubscribe` and `logsSubscribe` `all` / `allWithVotes` — can scale CU usage quickly.
+
+- Always scope with `mentions` / `mentionsAccountOrProgram` / `dataSize` / `memcmp` where supported.
+- Keep payloads small: prefer `encoding: "base64"` over `jsonParsed`, and `transactionDetails: "signatures"` when you don't need full tx data.
+- Set [usage limits](https://www.alchemy.com/docs/how-to-set-usage-limits-and-alerts-for-your-account) before deploying broad subscriptions in production.
+- See [Compute Unit Costs — Solana WebSocket Subscriptions](https://www.alchemy.com/docs/reference/compute-unit-costs#solana-websocket-subscriptions) for the per-byte CU rate.
+
+For higher-throughput, structured Solana streaming (account / slot / transaction streams with server-side filters), consider Yellowstone gRPC instead — see the `solana-grpc-*` references.
+
+---
+
 ## Notes
 
 - Subscriptions are stateful. Handle reconnects and resubscribe after reconnect.
@@ -208,3 +268,5 @@ ws.on("message", (data) => {
 ## Official Docs
 - [Subscription API Overview](https://www.alchemy.com/docs/reference/subscription-api)
 - [eth_subscribe](https://www.alchemy.com/docs/chains/ethereum/ethereum-api-endpoints/eth-subscribe)
+- [Solana Subscription API Endpoints](https://www.alchemy.com/docs/reference/solana-subscription-api-endpoints)
+- [accountSubscribe](https://www.alchemy.com/docs/reference/account-subscribe), [programSubscribe](https://www.alchemy.com/docs/reference/program-subscribe), [logsSubscribe](https://www.alchemy.com/docs/reference/logs-subscribe), [signatureSubscribe](https://www.alchemy.com/docs/reference/signature-subscribe), [slotSubscribe](https://www.alchemy.com/docs/reference/slot-subscribe), [rootSubscribe](https://www.alchemy.com/docs/reference/root-subscribe)

--- a/skills/alchemy-api/references/operational-supported-networks.md
+++ b/skills/alchemy-api/references/operational-supported-networks.md
@@ -9,7 +9,7 @@ tags:
 related:
   - node-json-rpc.md
   - solana-rpc.md
-updated: 2026-04-22
+updated: 2026-04-30
 ---
 # Supported Networks
 
@@ -195,6 +195,7 @@ polynomial-sepolia
 race-mainnet
 race-sepolia
 risa-testnet
+rise-mainnet
 rise-testnet
 ronin-mainnet
 ronin-saigon

--- a/skills/alchemy-api/references/skill-map.md
+++ b/skills/alchemy-api/references/skill-map.md
@@ -15,7 +15,7 @@ Complete index of all reference files organized by product area. Use the Endpoin
 | `references/node-json-rpc.md` | JSON-RPC (EVM) | Use Alchemy's EVM JSON-RPC endpoints for standard blockchain reads and writes (e.g., `eth_call`, `eth_getLogs`, `eth_sendRawTransaction`). This is the baseline for any EVM integration |
 | `references/node-trace-api.md` | Trace API | Trace APIs expose internal call data and state changes for transactions and blocks. Useful for analytics and auditing |
 | `references/node-utility-api.md` | Utility API | Convenience RPC methods that reduce round trips for common tasks like bulk transaction receipt retrieval |
-| `references/node-websocket-subscriptions.md` | WebSocket Subscriptions | Use WebSockets for real-time blockchain events without polling. Best for pending transactions, new blocks, and logs |
+| `references/node-websocket-subscriptions.md` | WebSocket Subscriptions | Use WebSockets for real-time blockchain events without polling. EVM uses `eth_subscribe`; Solana uses native `*Subscribe` / `*Unsubscribe` PubSub methods (`accountSubscribe`, `programSubscribe`, `logsSubscribe`, `signatureSubscribe`, `slotSubscribe`, `rootSubscribe`) |
 
 ## Data
 | File | Name | Short Description |
@@ -43,8 +43,8 @@ Complete index of all reference files organized by product area. Use the Endpoin
 ## Solana
 | File | Name | Short Description |
 | --- | --- | --- |
-| `references/solana-overview.md` | solana | Solana-specific APIs including standard JSON-RPC, Digital Asset Standard (DAS) for NFTs and compressed assets, and wallet integration. Use when building Solana applications that need RPC access, NFT/asset queries, or Solana wallet tooling. For high-throughput streaming, see the yellowstone-grpc skill |
-| `references/solana-das-api.md` | Solana DAS (Digital Asset Standard) API | DAS provides normalized access to Solana NFT and compressed asset data |
+| `references/solana-overview.md` | solana | Solana-specific APIs including standard JSON-RPC, Digital Asset Standard (DAS) for NFTs and Bubblegum compressed NFTs, the Photon indexer for ZK Compression, WebSocket PubSub subscriptions, and wallet integration. Use when building Solana applications that need RPC access, NFT/asset queries, ZK-compressed state, real-time event streams, or Solana wallet tooling. For high-throughput streaming, see the yellowstone-grpc skill |
+| `references/solana-das-api.md` | Solana DAS (Digital Asset Standard) API | DAS provides normalized access to Solana NFT and Bubblegum compressed NFT (cNFT) data. For ZK Compression accounts/tokens, use the Photon API instead (see solana-overview) |
 | `references/solana-grpc-best-practices.md` | Yellowstone Best Practices | Practical guidance to keep Yellowstone consumers reliable and efficient |
 | `references/solana-grpc-details.md` | Yellowstone gRPC Overview | Yellowstone gRPC provides high-throughput Solana data streams for blocks, transactions, accounts, and slots. Use this for real-time indexing at scale |
 | `references/solana-grpc-examples.md` | Yellowstone Examples | Minimal examples for connecting and subscribing. The exact client depends on your gRPC stack |

--- a/skills/alchemy-api/references/solana-overview.md
+++ b/skills/alchemy-api/references/solana-overview.md
@@ -1,10 +1,10 @@
 ---
 id: references/solana-overview.md
 name: solana
-description: Solana-specific APIs including standard JSON-RPC, Digital Asset Standard (DAS) for NFTs and compressed assets, and wallet integration. Use when building Solana applications that need RPC access, NFT/asset queries, or Solana wallet tooling. For high-throughput streaming, see the yellowstone-grpc skill.
+description: Solana-specific APIs including standard JSON-RPC, Digital Asset Standard (DAS) for NFTs and Bubblegum compressed NFTs, the Photon indexer for ZK Compression accounts/tokens, WebSocket PubSub subscriptions, and wallet integration. Use when building Solana applications that need RPC access, NFT/asset queries, ZK-compressed state, real-time event streams, or Solana wallet tooling. For high-throughput streaming, see the yellowstone-grpc skill.
 tags: []
 related: []
-updated: 2026-02-14
+updated: 2026-04-30
 metadata:
   author: alchemyplatform
   version: "1.0"
@@ -16,8 +16,14 @@ Solana-specific APIs and streaming endpoints, including DAS (Digital Asset Stand
 
 ## References (Recommended Order)
 1. [solana-rpc.md](solana-rpc.md) - Standard Solana JSON-RPC usage patterns.
-2. [solana-das-api.md](solana-das-api.md) - DAS endpoints for assets and metadata.
+2. [solana-das-api.md](solana-das-api.md) - DAS endpoints for NFTs and Bubblegum compressed NFTs.
 3. [solana-wallets.md](solana-wallets.md) - Solana wallet integration notes.
+4. [node-websocket-subscriptions.md](node-websocket-subscriptions.md) - Solana PubSub subscriptions (`accountSubscribe`, `programSubscribe`, `logsSubscribe`, `signatureSubscribe`, `slotSubscribe`, `rootSubscribe`).
+
+## Photon API (ZK Compression)
+Alchemy serves the [Photon](https://github.com/helius-labs/photon) indexer on the standard Solana endpoints. Photon exposes [ZK Compression](https://www.zkcompression.com/) state — compressed accounts, compressed token balances, and compression-related signatures — via JSON-RPC. Methods include `getCompressedAccount`, `getCompressedAccountsByOwner`, `getCompressedTokenAccountsByOwner`, `getCompressedTokenBalancesByOwnerV2`, `getValidityProof` / `getValidityProofV2`, and the `getCompressionSignaturesFor*` family. Use the same Solana endpoint URL (`https://solana-mainnet.g.alchemy.com/v2/<API_KEY>` or `solana-devnet`).
+
+Note: ZK Compression (Photon) and Bubblegum compressed NFTs (DAS) are **different** primitives. Photon is for arbitrary ZK-compressed accounts/tokens; DAS `getAsset` / `getAssetProof` is for Bubblegum cNFTs.
 
 ## Cross-References
 - `yellowstone-grpc` skill for high-throughput streaming (accounts/transactions/blocks).
@@ -30,3 +36,5 @@ Solana-specific APIs and streaming endpoints, including DAS (Digital Asset Stand
 ## Official Docs
 - [Solana API Quickstart](https://www.alchemy.com/docs/reference/solana-api-quickstart)
 - [DAS APIs for Solana](https://www.alchemy.com/docs/reference/alchemy-das-apis-for-solana)
+- [Photon APIs for Solana ZK Compression](https://www.alchemy.com/docs/reference/alchemy-photon-apis-for-solana)
+- [Solana Subscription API Endpoints](https://www.alchemy.com/docs/reference/solana-subscription-api-endpoints)


### PR DESCRIPTION
## Summary

Weekly skills sync covering docs PRs merged in the last 7 days. Updates only land for changes that materially affect how an agent uses the API.

## Files updated (mirrored to both `skills/` and `plugins/alchemy/skills/`)

### `alchemy-api/references/node-websocket-subscriptions.md`
- Adds a **Solana PubSub Subscriptions** section: `accountSubscribe`, `programSubscribe`, `logsSubscribe`, `signatureSubscribe`, `slotSubscribe`, `rootSubscribe`, with notification-name mapping, an `@solana/web3.js` example, and bandwidth-billing scoping guidance.
- Tagline / frontmatter updated to clarify EVM uses `eth_subscribe` while Solana uses native `*Subscribe` / `*Unsubscribe` PubSub methods.
- Adds Solana subscription docs to the Official Docs footer.
- Reflects docs PR alchemyplatform/docs#1234.

### `alchemy-api/references/solana-overview.md`
- Adds a **Photon API (ZK Compression)** section listing the main methods (`getCompressedAccount`, `getCompressedAccountsByOwner`, `getCompressedTokenAccountsByOwner`, `getValidityProof`/`V2`, the `getCompressionSignaturesFor*` family, etc.).
- Clarifies that **ZK Compression (Photon)** and **Bubblegum compressed NFTs (DAS)** are different primitives — agents previously got a conflated picture from the old "compressed assets" wording.
- Adds Solana PubSub subscriptions to the recommended-order references.
- Reflects docs PR alchemyplatform/docs#1240.

### `alchemy-api/references/skill-map.md`
- Refreshes `node-websocket-subscriptions` and `solana-overview` rows with the new Solana coverage.
- Tightens the `solana-das-api` row to point ZK Compression callers at Photon.

### `alchemy-api/references/operational-supported-networks.md`
- Adds `rise-mainnet` alongside `rise-testnet`. Reflects docs PR alchemyplatform/docs#1274.

## PRs reviewed but **no skills change needed**
- #1230, #1258, #1267 — Privy signer migration guides and `/docs/` link prefix fixes. Privy migration is product-specific content, not in the skills audience.
- #1255 — single CU bullet for `alchemy_requestFeePayer` with `prefundRent`. Skills don't enumerate per-method CU costs; agents resolve those from the live pricing page.
- #1254 — cosmetic icon fix.
- #1269 — wallets CONTRIBUTING.md edit; not exposed via skills.
- #1270 — Aptos / Avalanche Snapshots tutorial deprecation; Snapshots tutorials aren't in skills.

## Verification
`git diff --stat` shows 8 files changed (4 unique + the same 4 mirrored), 162 insertions, 20 deletions.