### PR TITLE
feat(ecosystem): add LI.FI skill (cross-chain swap + bridge)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "alchemy",
   "skills": [
-    "./skills/ecosystem/allium"
+    "./skills/ecosystem/allium",
+    "./skills/ecosystem/lifi"
   ]
 }

--- a/skills/ecosystem/lifi/LICENSE.txt
+++ b/skills/ecosystem/lifi/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LI.FI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ecosystem/lifi/SKILL.md
+++ b/skills/ecosystem/lifi/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: lifi
+description: Query LI.FI's API for cross-chain and same-chain token swap + bridge routing across 60+ blockchains. Aggregates 27 bridges and 31 DEXs (1inch, 0x, Paraswap, DODO, OpenOcean, etc.) under one interface — get quotes with ready-to-execute transaction data, compare multi-step routes, and track cross-chain transfer status. NOT for token prices, token metadata, current wallet balance snapshots, transaction history, or NFT data — for those use `alchemy-cli` (live), `alchemy-mcp`, `alchemy-api` (app code), or `agentic-gateway` (no API key). API key optional but recommended for production rate limits.
+license: MIT
+compatibility: API key optional via `$LIFI_API_KEY` (`x-lifi-api-key` header) for higher rate limits — register at https://li.fi. Network access required. Endpoints return ready-to-execute `transactionRequest` objects; the user / app signs and submits.
+metadata:
+  author: lifi
+  version: "0.1"
+  provider: lifi
+  partner: "true"
+---
+
+# LI.FI (Cross-Chain Swap + Bridge Routing)
+
+LI.FI aggregates 27 bridges and 31 DEXs across 60+ chains into a single quote/route API. This skill covers cross-chain and same-chain swap routing, bridge transfers, and transaction status tracking. For token prices, token metadata, current wallet balances, transaction history, or live RPC reads, use the corresponding Alchemy skill instead.
+
+| | |
+| --- | --- |
+| **Base URL** | `https://li.quest/v1` |
+| **Auth** | `x-lifi-api-key: $LIFI_API_KEY` header (optional but recommended for production rate limits) |
+| **Aggregates** | 27 bridges + 31 DEXs across 60+ chains (EVM + SVM) |
+| **Free tier** | Public access without a key, lower rate limits |
+
+## When to use this skill
+
+Use `lifi` when **any** of the following are true:
+
+- The user wants to **swap tokens between two chains** (e.g., USDC on Ethereum → ETH on Arbitrum)
+- The user wants to **bridge tokens** to another chain (e.g., move ETH from mainnet to Optimism)
+- The user wants the **best swap rate on a single chain** (LI.FI aggregates DEXs)
+- The user wants to **track status** of an in-flight cross-chain transfer
+- The user wants to **discover** supported chains / tokens / bridges programmatically
+
+## When NOT to use this skill (handoff)
+
+| Need | Use instead |
+| --- | --- |
+| Token prices (current, historical, by-timestamp) | `alchemy-api` (Prices API) |
+| Token metadata, search, list by chain | `alchemy-api` (Token API) |
+| Current wallet balances (point-in-time) | `alchemy-api` (Portfolio / Token API) |
+| Transaction history (transfers, asset movements) | `alchemy-api` (Transfers API) |
+| NFT metadata / floor / ownership | `alchemy-api` (NFT API) |
+| Live blockchain reads (block #, gas, `eth_call`) | `alchemy-cli` (live work) or `alchemy-api` (JSON-RPC) |
+| Signed transaction submission | the app's wallet / `alchemy-api` |
+| Transaction simulation pre-execution | `alchemy-api` (Simulation API) |
+| Account abstraction (bundlers, gas managers) | `alchemy-api` |
+
+## Scope contract
+
+**This skill covers (`scope_in`):**
+
+- Single-step quotes with ready-to-execute transaction data (`GET /quote`)
+- Multi-route comparison (`POST /advanced/routes`) and step-level transaction population (`POST /advanced/stepTransaction`)
+- Cross-chain transfer status tracking (`GET /status`)
+- Discovery — supported chains (`GET /chains`), per-chain token lists (`GET /tokens`, `GET /token`), bridges + DEXs (`GET /tools`), connectivity (`GET /connections`)
+
+**This skill does NOT cover (`scope_out`):**
+
+- Token prices → handoff: `alchemy-api` (Prices API)
+- Token metadata, search, list (LI.FI returns tokens for routing, not general lookup) → handoff: `alchemy-api` (Token API)
+- Current wallet balances (point-in-time) → handoff: `alchemy-api` (Portfolio / Token API)
+- Transaction transfer history → handoff: `alchemy-api` (Transfers API)
+- NFT metadata / floor prices → handoff: `alchemy-api` (NFT API)
+- Live RPC reads, gas estimation, block details → handoff: `alchemy-cli` or `alchemy-api` (JSON-RPC)
+- Signed tx submission → user's wallet (LI.FI returns `transactionRequest`; app signs and submits)
+- Pre-execution simulation beyond what LI.FI runs internally → handoff: `alchemy-api` (Simulation API)
+- Account abstraction → handoff: `alchemy-api` (Wallets / Bundler / Gas Manager)
+
+## Setup
+
+API key is optional. Without one, requests are rate-limited per IP. With one, rate-limited per key (higher tier).
+
+Register for an API key at [li.fi](https://li.fi) and store it as `LIFI_API_KEY`:
+
+```bash
+export LIFI_API_KEY="..."
+```
+
+Public discovery works without auth:
+
+```bash
+curl "https://li.quest/v1/chains"
+```
+
+For production rate limits, include the header on every call:
+
+```bash
+curl "https://li.quest/v1/chains" \
+  -H "x-lifi-api-key: $LIFI_API_KEY"
+```
+
+> **Security:** never expose `LIFI_API_KEY` in client-side code. Use it server-side only.
+
+## Endpoint reference → [references/routing.md](./references/routing.md)
+
+### Routing
+
+| Endpoint | Use for |
+| --- | --- |
+| `GET /quote` | Single-step quote + ready-to-execute `transactionRequest`. Use for "I want X on chain B from Y on chain A". |
+| `POST /advanced/routes` | Compare multiple routes; returns steps without TX data. Use to inspect route options, fees, gas estimates. |
+| `POST /advanced/stepTransaction` | Populate a chosen step with `transactionRequest`. Use after picking a route from `/advanced/routes`. |
+| `GET /status` | Poll cross-chain transfer status. Returns `PENDING` → `DONE` / `FAILED`. |
+
+### Discovery
+
+| Endpoint | Use for |
+| --- | --- |
+| `GET /chains` | List supported chains (EVM + SVM). |
+| `GET /tokens` | Token list per chain (filter by `minPriceUSD`). |
+| `GET /token` | Resolve a single token by address or symbol on a specific chain. |
+| `GET /tools` | Available bridges + DEXs that LI.FI aggregates. |
+| `GET /connections` | Which chain pairs / token pairs are routable. |
+
+## Quick examples
+
+### Cross-chain swap quote (USDC on Arbitrum → DAI on Optimism)
+
+```bash
+curl "https://li.quest/v1/quote?\
+fromChain=42161&\
+toChain=10&\
+fromToken=0xaf88d065e77c8cC2239327C5EDb3A432268e5831&\
+toToken=0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1&\
+fromAmount=10000000&\
+fromAddress=0xYourAddress&\
+slippage=0.005" \
+  -H "x-lifi-api-key: $LIFI_API_KEY"
+```
+
+Response includes `transactionRequest.{to, data, value, gasLimit}` ready for the user's wallet to sign + submit. Pass the resulting tx hash to `/status` to track.
+
+### Same-chain swap (native ETH → USDC on Polygon)
+
+```bash
+curl "https://li.quest/v1/quote?\
+fromChain=137&\
+toChain=137&\
+fromToken=0x0000000000000000000000000000000000000000&\
+toToken=0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174&\
+fromAmount=1000000000000000000&\
+fromAddress=0xYourAddress&\
+slippage=0.005"
+```
+
+### Track cross-chain status
+
+```bash
+curl "https://li.quest/v1/status?txHash=0xSendingTxHash&fromChain=42161&toChain=10"
+```
+
+Status values: `NOT_FOUND`, `INVALID`, `PENDING`, `DONE`, `FAILED`. Poll until `DONE` or `FAILED`.
+
+### List supported chains
+
+```bash
+curl "https://li.quest/v1/chains"
+curl "https://li.quest/v1/chains?chainTypes=EVM,SVM"
+```
+
+## Common gotchas
+
+- **`fromAmount` is in smallest unit** (no decimals applied). 10 USDC = `10000000` (USDC has 6 decimals), not `10`.
+- **`fromAddress` is required** even though no signing happens server-side — it's used to build the `transactionRequest`.
+- **`slippage` defaults to ~0.005 (0.5%)**. For volatile pairs, raise it explicitly.
+- **Native gas tokens** use the zero address `0x0000000000000000000000000000000000000000`, not a wrapped-token address.
+- **Status polling**: cross-chain transfers take 10s–10min depending on the bridge. Don't fail your flow on `PENDING`.
+- **Rate limits**: without an API key, LI.FI rate-limits per IP. If you're getting 429s, register for a key.
+- **Route preferences** (`order=FASTEST` vs. `CHEAPEST`) materially change route selection — `FASTEST` may pick higher-fee but quicker bridges (e.g., Stargate over Hop).
+
+## Routing back to Alchemy
+
+If during a session the user's need shifts to surfaces this skill doesn't cover (token prices, token metadata, wallet balances, transaction history, NFT data) or to live RPC / writes / simulation, hand off:
+
+- `alchemy-cli` — live agent work in the current session via the local CLI
+- `alchemy-mcp` — live work via the hosted MCP server when CLI is not installed
+- `alchemy-api` — application code with an Alchemy API key
+- `agentic-gateway` — application code without an API key (x402 / MPP)
+
+---
+
+> **Maintenance:** LI.FI maintains the underlying API surface; this skill itself is maintained jointly by Alchemy and LI.FI. File issues against `alchemyplatform/skills` with `[ecosystem/lifi]` in the title.

--- a/skills/ecosystem/lifi/agents/openai.yaml
+++ b/skills/ecosystem/lifi/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LI.FI"
+  short_description: "Cross-chain and same-chain swap + bridge routing across 60+ chains via LI.FI"
+  default_prompt: "Use LI.FI for cross-chain or same-chain token swaps and bridge transfers — get a quote, compare routes, or track status of an in-flight cross-chain transfer. For token prices, balances, transaction history, or NFT data, use alchemy-api instead."

--- a/skills/ecosystem/lifi/references/routing.md
+++ b/skills/ecosystem/lifi/references/routing.md
@@ -1,0 +1,243 @@
+# LI.FI Routing & Discovery Reference
+
+**Base URL:** `https://li.quest/v1` · **Auth:** `x-lifi-api-key: $LIFI_API_KEY` (optional)
+
+These endpoints are non-overlapping with Alchemy first-party. For token prices, token metadata, balances, transfers, or live RPC reads, route to `alchemy-api`.
+
+---
+
+## `GET /quote`
+
+Single-step quote with `transactionRequest` populated. Easiest path for "swap X on chain A to Y on chain B".
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `fromChain` | number | Yes | Source chain ID |
+| `toChain` | number | Yes | Destination chain ID |
+| `fromToken` | string | Yes | Source token address (use `0x0000…` for native gas token) |
+| `toToken` | string | Yes | Destination token address |
+| `fromAmount` | string | Yes | Amount in smallest unit (no decimals applied) |
+| `fromAddress` | string | Yes | Sender wallet address |
+| `toAddress` | string | No | Recipient address (defaults to `fromAddress`) |
+| `slippage` | number | No | Slippage tolerance (`0.005` = 0.5%; default ~0.5%) |
+| `integrator` | string | No | Your integrator ID (used for fee accounting) |
+| `order` | string | No | `FASTEST` or `CHEAPEST` (default: `RECOMMENDED`) |
+| `allowBridges` / `denyBridges` / `preferBridges` | string[] | No | Filter or steer bridge selection |
+| `allowExchanges` / `denyExchanges` / `preferExchanges` | string[] | No | Filter or steer DEX selection |
+| `allowDestinationCall` | boolean | No | Allow contract calls on destination (default `true`) |
+| `fee` | number | No | Integrator fee (`0.02` = 2%, max < 100%) |
+| `maxPriceImpact` | number | No | Max price impact threshold (`0.1` = 10%; default 10%) |
+
+### Example
+
+```bash
+curl "https://li.quest/v1/quote?\
+fromChain=42161&\
+toChain=10&\
+fromToken=0xaf88d065e77c8cC2239327C5EDb3A432268e5831&\
+toToken=0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1&\
+fromAmount=10000000&\
+fromAddress=0xYourAddress&\
+slippage=0.005&\
+order=CHEAPEST" \
+  -H "x-lifi-api-key: $LIFI_API_KEY"
+```
+
+### Key response fields
+
+- `transactionRequest.{to, data, value, gasLimit, gasPrice, chainId}` — ready for `eth_sendTransaction`
+- `estimate.{fromAmount, toAmount, toAmountMin, executionDuration, feeCosts, gasCosts}` — UX preview
+- `action.{fromToken, toToken, fromAddress, toAddress, slippage}` — echoes inputs
+- `tool` — selected aggregator/bridge name
+- `id` — quote ID (handy for support tickets)
+
+---
+
+## `POST /advanced/routes`
+
+Multi-route comparison. Returns routes without `transactionRequest` data — use this when you want to **inspect** options before committing.
+
+### Body
+
+```json
+{
+  "fromChainId": 42161,
+  "toChainId": 10,
+  "fromTokenAddress": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+  "toTokenAddress": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+  "fromAmount": "10000000",
+  "fromAddress": "0xYourAddress",
+  "options": {
+    "integrator": "YourAppName",
+    "slippage": 0.005,
+    "order": "CHEAPEST",
+    "bridges": { "allow": ["stargate", "hop", "across"] },
+    "exchanges": { "allow": ["1inch", "uniswap"] },
+    "allowSwitchChain": true,
+    "maxPriceImpact": 0.1
+  }
+}
+```
+
+### Example
+
+```bash
+curl -X POST "https://li.quest/v1/advanced/routes" \
+  -H "Content-Type: application/json" \
+  -H "x-lifi-api-key: $LIFI_API_KEY" \
+  -d '{
+    "fromChainId": 42161,
+    "toChainId": 10,
+    "fromTokenAddress": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    "toTokenAddress": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+    "fromAmount": "10000000",
+    "options": { "slippage": 0.005, "integrator": "YourApp" }
+  }'
+```
+
+### Response
+
+Array of `Route` objects sorted by `order` preference. Each route has `steps[]` describing the bridge / DEX hops, plus aggregate `fromAmount`, `toAmount`, `gasCostUSD`, `executionDuration`. **No `transactionRequest`** — call `/advanced/stepTransaction` to populate the chosen step.
+
+---
+
+## `POST /advanced/stepTransaction`
+
+Populate a specific step from `/advanced/routes` with the `transactionRequest`.
+
+### Body
+
+Send the full `Step` object (from a chosen route's `steps[]`).
+
+### Query parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `skipSimulation` | boolean | No | Skip TX simulation for faster response |
+
+### Response
+
+The same `Step` object with `transactionRequest` now populated.
+
+---
+
+## `GET /status`
+
+Track cross-chain (or same-chain) transfer status. Polling endpoint — invoke after the user submits the `transactionRequest` from `/quote` or `/advanced/stepTransaction`.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `txHash` | string | Yes | Sending tx hash, receiving tx hash, or `transactionId` |
+| `fromChain` | number | No | Source chain ID (speeds up resolution) |
+| `toChain` | number | No | Destination chain ID |
+| `bridge` | string | No | Bridge tool name (from `/quote` response) |
+
+For same-chain swaps, set `fromChain` and `toChain` to the same value.
+
+### Example
+
+```bash
+curl "https://li.quest/v1/status?txHash=0xSendingTxHash&fromChain=42161&toChain=10"
+```
+
+### Response
+
+```json
+{
+  "transactionId": "...",
+  "sending":    { "txHash": "0x...", "amount": "...", "chainId": 42161, "token": {...} },
+  "receiving":  { "txHash": "0x...", "amount": "...", "chainId": 10,    "token": {...} },
+  "status":     "DONE",
+  "substatus":  "COMPLETED",
+  "lifiExplorerLink": "https://scan.li.fi/tx/..."
+}
+```
+
+### Status values
+
+`NOT_FOUND` · `INVALID` · `PENDING` · `DONE` · `FAILED`
+
+Poll until `DONE` or `FAILED`. Substatuses include `WAIT_SOURCE_CONFIRMATIONS`, `WAIT_DESTINATION_TRANSACTION`, `BRIDGE_NOT_AVAILABLE`, `CHAIN_NOT_AVAILABLE`, `REFUNDED`, `COMPLETED` — see [li.fi docs](https://docs.li.fi/) for the full list.
+
+---
+
+## `GET /chains`
+
+List supported chains.
+
+```bash
+curl "https://li.quest/v1/chains"
+curl "https://li.quest/v1/chains?chainTypes=EVM,SVM"
+```
+
+Returns array of `Chain` objects with `id`, `name`, `key`, `chainType`, `nativeToken`, `metamask` (RPC / explorer URLs), `multicallAddress`, etc.
+
+## `GET /tokens`
+
+List tokens for one or more chains.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `chains` | string | No | Comma-separated chain IDs or keys (e.g., `1,137` or `ETH,POL`) |
+| `chainTypes` | string | No | Filter by chain types: `EVM`, `SVM` |
+| `minPriceUSD` | number | No | Min token price filter (default `0.0001`) |
+
+```bash
+curl "https://li.quest/v1/tokens?chains=1,137,42161"
+```
+
+> **Note:** for general token metadata lookup outside the swap-routing context, prefer `alchemy-api` (Token API). LI.FI's token list is curated for routing purposes — it omits unroutable tokens.
+
+## `GET /token`
+
+Resolve a single token.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `chain` | string | Yes | Chain ID or key |
+| `token` | string | Yes | Token address or symbol |
+
+```bash
+curl "https://li.quest/v1/token?chain=POL&token=DAI"
+```
+
+## `GET /tools`
+
+Available bridges + DEXs.
+
+```bash
+curl "https://li.quest/v1/tools"
+```
+
+Returns `bridges[]` and `exchanges[]` with names, supported chains, fees, etc. Useful when the user asks "what bridges does LI.FI use?" or to constrain `allowBridges` / `allowExchanges` in `/quote`.
+
+## `GET /connections`
+
+Which chain pairs / token pairs are routable.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `fromChain` | number | No | Source chain |
+| `toChain` | number | No | Destination chain |
+| `fromToken` | string | No | Source token |
+| `toToken` | string | No | Destination token |
+
+```bash
+curl "https://li.quest/v1/connections?fromChain=1&toChain=137"
+```
+
+Useful for "is X → Y supported?" checks before constructing a quote.
+
+---
+
+## Common gotchas
+
+- `/history` and similar reads (transfer history) — **not exposed by LI.FI**. Route to `alchemy-api` (Transfers API).
+- Token prices are sometimes returned alongside `/quote` responses for UX — these are **routing-context prices**, not authoritative. For pricing, route to `alchemy-api` (Prices API).
+- `transactionRequest.value` is in hex wei. The wallet handles the conversion when signing.
+- For SVM (Solana), responses include Solana-shaped transaction encodings — handle separately from EVM.
+- Bridge status can flip from `PENDING` → `DONE` and back to `PENDING` if the destination chain reorgs (rare). Treat `DONE` as eventually-final, not strictly-final.


### PR DESCRIPTION
## Summary

- Adds **LI.FI** as an ecosystem partner skill (`skills/ecosystem/lifi/`), curated subset of [`lifinance/lifi-agent-skills`](https://github.com/lifinance/lifi-agent-skills)
- LI.FI aggregates **27 bridges and 31 DEXs** (1inch, 0x, Paraswap, DODO, OpenOcean, etc.) across **60+ chains** under a single quote/route/status API
- Adds the path to `.claude-plugin/plugin.json` so the Vercel `npx skills` CLI discovers it

## Scope

**In:** routing (`/quote`, `/advanced/routes`, `/advanced/stepTransaction`), status tracking (`/status`), discovery (`/chains`, `/tokens`, `/token`, `/tools`, `/connections`).

**Out (routes back to first-party Alchemy):** token prices → Prices API · token metadata → Token API · current balances → Portfolio API · transaction history → Transfers API · NFT data → NFT API · live RPC → JSON-RPC · simulation → Simulation API · AA → Wallets/Bundler/Gas Manager. The full handoff table is in the SKILL.md.

## Test plan

- [x] `npx skills add . --list` finds 6 skills (was 5): `lifi` joins `allium` under "Alchemy" group from manifest; first-party 4 still under "General" from default scan
- [x] LiFi `scope_in` audited against `alchemy-api` (Token, Portfolio, Prices, Transfers, NFT, Simulation, JSON-RPC) — zero overlap; LI.FI's value is cross-chain routing and bridge aggregation, surfaces Alchemy doesn't provide first-party