### PR TITLE
feat(ecosystem): add Morpho skill (lending - vaults, markets, positions)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "alchemy",
   "skills": [
-    "./skills/ecosystem/allium"
+    "./skills/ecosystem/allium",
+    "./skills/ecosystem/morpho"
   ]
 }

--- a/skills/ecosystem/morpho/LICENSE.txt
+++ b/skills/ecosystem/morpho/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Morpho Association
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ecosystem/morpho/SKILL.md
+++ b/skills/ecosystem/morpho/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: morpho
+description: Drive the Morpho lending protocol from the terminal via `npx @morpho-org/cli@latest` — query vaults / markets / positions / health factor and prepare unsigned Morpho transactions (deposit, withdraw, supply, borrow, repay, supply-collateral, withdraw-collateral) with built-in simulation on Ethereum and Base. Covers Morpho Blue isolated lending markets, Morpho Vaults v2 (ERC-4626), and MetaMorpho (vault v1). NOT for token prices, token metadata, current wallet balances outside Morpho positions, transaction transfer history, NFTs, or live RPC reads — for those use `alchemy-cli` (live), `alchemy-mcp`, `alchemy-api` (app code), or `agentic-gateway` (no API key). No API key required; needs Node.js and `npx`.
+license: MIT
+compatibility: Requires Node.js (≥ 18) and `npx` available locally. No API key required. Network access required. Supported chains via the CLI: `ethereum`, `base`. CLI prepares unsigned transactions; the user signs and submits via their wallet.
+metadata:
+  author: morpho
+  version: "0.1"
+  provider: morpho
+  partner: "true"
+---
+
+# Morpho (Lending — Vaults, Markets, Positions)
+
+Morpho is a permissionless lending protocol with isolated markets and curated vaults. This skill drives the official `@morpho-org/cli` to query protocol state and prepare unsigned Morpho transactions with simulation. For token prices, balances outside Morpho, transfers, NFTs, or live RPC, use the corresponding Alchemy skill instead.
+
+| | |
+| --- | --- |
+| **Tool** | `npx @morpho-org/cli@latest <command>` |
+| **Auth** | None — public reads + unsigned-tx prep |
+| **Chains** | `ethereum`, `base` (every command requires `--chain`) |
+| **Output** | JSON to stdout (use `--fields` / `--sort` / `--limit` to shape) |
+| **Status** | Experimental (pre-v1.0); command syntax may evolve |
+
+## When to use this skill
+
+Use `morpho` when **any** of the following are true:
+
+- The user wants to **explore Morpho vault APYs / TVL / allocations** ("best USDC vault on Base")
+- The user wants to **compare Morpho Blue markets** ("ETH/USDC markets on mainnet")
+- The user wants to **inspect Morpho positions** or **health factor** ("what are my Morpho positions")
+- The user wants to **prepare a Morpho operation** — deposit, withdraw, supply, borrow, repay, supply/withdraw collateral
+- The user wants to **simulate** a Morpho operation before signing
+
+## When NOT to use this skill (handoff)
+
+| Need | Use instead |
+| --- | --- |
+| Token prices (current, historical, by-timestamp) | `alchemy-api` (Prices API) |
+| Token metadata, search, list by chain | `alchemy-api` (Token API) |
+| Wallet balances *outside* Morpho positions | `alchemy-api` (Portfolio / Token API) |
+| Transaction history (transfers in / out) | `alchemy-api` (Transfers API) |
+| NFT metadata / floor / ownership | `alchemy-api` (NFT API) |
+| Live blockchain reads (block #, gas, `eth_call`) | `alchemy-cli` (live) or `alchemy-api` (JSON-RPC) |
+| Other lending protocols (Aave, Compound, Spark, etc.) | their respective skills, or `alchemy-api` JSON-RPC |
+| Curator / allocator / market creation, liquidations, flashloans, rewards | upstream `@morpho-org/morpho-builder` skill (lower-level SDKs) |
+| Pre-execution simulation beyond Morpho's built-in | `alchemy-api` (Simulation API) |
+| Account abstraction (bundlers, gas managers) | `alchemy-api` |
+| Signed transaction submission | the app's wallet / `alchemy-api` |
+
+## Scope contract
+
+**This skill covers (`scope_in`):**
+
+- Reads: `query-vaults`, `get-vault`, `query-markets`, `get-market`, `get-positions`, `get-token-balance`, `health-check`, `get-supported-chains`
+- Writes (unsigned tx prep with simulation by default): `prepare-deposit`, `prepare-withdraw`, `prepare-supply`, `prepare-borrow`, `prepare-repay`, `prepare-supply-collateral`, `prepare-withdraw-collateral`
+- Standalone simulation: `simulate-transactions`
+- Coverage: Morpho Blue isolated markets, Morpho Vaults v2 (ERC-4626), MetaMorpho (vault v1)
+
+**This skill does NOT cover (`scope_out`):**
+
+- Token prices → handoff: `alchemy-api` (Prices API)
+- Token metadata, list, search → handoff: `alchemy-api` (Token API)
+- Wallet balances outside Morpho positions → handoff: `alchemy-api` (Portfolio / Token API)
+- Transaction transfer history → handoff: `alchemy-api` (Transfers API)
+- NFT data → handoff: `alchemy-api` (NFT API)
+- Live RPC reads (block details, gas, contract calls outside Morpho) → handoff: `alchemy-cli` or `alchemy-api` (JSON-RPC)
+- Other lending protocols → not covered; use protocol-specific skills or raw RPC
+- Curator / allocator ops, market creation, liquidations, flashloans, pre-liquidation, rewards claiming → out of scope (use upstream `@morpho-org/morpho-builder` skill or lower-level Morpho SDKs)
+- Pre-execution simulation beyond Morpho's built-in → handoff: `alchemy-api` (Simulation API)
+- Account abstraction → handoff: `alchemy-api` (Wallets / Bundler / Gas Manager)
+- Signed tx submission → user's wallet (CLI returns unsigned payloads; app signs)
+
+## Setup
+
+No API key required. Needs Node.js (≥ 18) and `npx`:
+
+```bash
+node --version   # should be ≥ 18
+npx @morpho-org/cli@latest health-check
+```
+
+The CLI is fetched via `npx` on each invocation; pin a version with `@<version>` if you want stability. Prefer `@latest` during this skill's experimental window.
+
+## Endpoint reference → [references/cli.md](./references/cli.md)
+
+### Read commands
+
+| Command | Use for |
+| --- | --- |
+| `query-vaults` | List MetaMorpho / Vault v2 vaults — sortable by APY / TVL |
+| `get-vault` | Single vault details (allocation, fees, curator, role list) |
+| `query-markets` | List Morpho Blue markets — filter by loan/collateral asset, sort by APY / liquidity / utilization |
+| `get-market` | Single market details (LLTV, IRM, oracle, supply / borrow / collateral assets) |
+| `get-positions` | All Morpho positions for an address (across vaults + markets) |
+| `get-token-balance` | Token balance for a specific (user, token) pair |
+| `health-check` | Sanity check the CLI + RPC connection |
+| `get-supported-chains` | List supported chain names |
+
+### Write commands (prepare unsigned txs; simulation runs by default)
+
+| Command | Use for |
+| --- | --- |
+| `prepare-deposit` | Deposit into a vault (V1 or V2) — returns unsigned tx + simulation outcome |
+| `prepare-withdraw` | Withdraw from a vault; supports `--amount max` |
+| `prepare-supply` | Supply loan asset to a Morpho Blue market |
+| `prepare-borrow` | Borrow against existing collateral (warns if health factor < 1.1) |
+| `prepare-repay` | Repay borrow; supports `--amount max` |
+| `prepare-supply-collateral` | Supply collateral to a market |
+| `prepare-withdraw-collateral` | Withdraw collateral; supports `--amount max` |
+
+### Standalone simulation
+
+| Command | Use for |
+| --- | --- |
+| `simulate-transactions` | Re-simulate with different parameters or simulate arbitrary tx bundles |
+
+## Quick examples
+
+### Find the best USDC vault on Base
+
+```bash
+npx @morpho-org/cli@latest query-vaults \
+  --chain base \
+  --asset-symbol USDC \
+  --sort apy_desc \
+  --limit 5 \
+  --fields address,name,symbol,apyPct,tvlUsd,feePct
+```
+
+### Inspect a user's Morpho positions on mainnet
+
+```bash
+npx @morpho-org/cli@latest get-positions \
+  --chain ethereum \
+  --user-address 0xUserAddress
+```
+
+### Prepare a vault deposit (with simulation)
+
+```bash
+npx @morpho-org/cli@latest prepare-deposit \
+  --chain base \
+  --vault-address 0xVaultAddress \
+  --user-address 0xUserAddress \
+  --amount 1000
+```
+
+The response includes:
+- `summary` — human-readable description
+- `transactions` — array of unsigned payloads to sign (includes any required ERC-20 approvals)
+- `simulated`, `simulationOk` — was simulation run; did it succeed
+- `outcome.vault.{sharesReceived, assetsReceived, positionAssets, positionShares}` — post-execution effect
+- `warnings[]` — partial-fill notices (especially for `prepare-withdraw --amount max`)
+
+### Borrow against collateral (with health-factor check)
+
+```bash
+npx @morpho-org/cli@latest prepare-borrow \
+  --chain base \
+  --market-id 0xMarketId \
+  --user-address 0xUserAddress \
+  --borrow-amount 1
+```
+
+The response's `outcome.market` includes `healthFactor`, `isHealthy`, `maxBorrowable`, and before/after `utilizationPct` + `borrowApyPct`. Surface these to the user before they sign.
+
+## Common gotchas
+
+- **`--chain` is required** on every command — no default. Use chain **names** (`ethereum`, `base`), not chain IDs.
+- **Amount units**: `--amount` is human-readable (`1000` for 1,000 USDC), not raw units. The CLI handles decimals.
+- **Decimal-applied vs. raw values in output**: `TokenAmount` values, `*Pct` fields, and `*Usd` fields are already converted (a USDC value of `"1000"` means $1,000). The **only** raw integer strings are inside `outcome.market.{supplied, borrowed, collateral}` and `outcome.vault.{sharesReceived, assetsReceived, positionShares}` — those need `/10^decimals` for display.
+- **Token decimals vary**: USDC/USDT = 6, WBTC/cbBTC = 8, WETH/DAI = 18. Read decimals from response metadata; never assume.
+- **Always check simulation before presenting** — `prepare-*` runs simulation by default. Inspect `simulationOk` (`true` / `false`) and `outcome.*.revertReason` if it failed.
+- **Health-factor warnings**: borrows with `healthFactor < 1.1` should be flagged to the user. The CLI warns; surface the warning verbatim.
+- **Partial withdrawals**: when `prepare-withdraw --amount max` can't withdraw the full balance (vault liquidity shortfall), the response is still valid — it represents the largest withdrawable amount right now. Surface `warnings[]` and offer to wait or accept partial.
+- **Vault v1 vs v2 ABIs are incompatible**: when interacting via raw RPC, use `metaMorphoAbi` for v1 (`Vault`) and `vaultV2Abi` for v2 (`VaultV2`). The CLI handles this internally.
+- **Singleton contract** for Morpho Blue: `0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb` — same address on Ethereum (chain 1) and Base (chain 8453) via CREATE2.
+
+## Routing back to Alchemy
+
+If during a session the user's need shifts to surfaces this skill doesn't cover (token prices, balances outside Morpho, transaction history, NFT data) or to live RPC / writes / simulation outside Morpho, hand off:
+
+- `alchemy-cli` — live agent work in the current session via the local CLI
+- `alchemy-mcp` — live work via the hosted MCP server when CLI is not installed
+- `alchemy-api` — application code with an Alchemy API key
+- `agentic-gateway` — application code without an API key (x402 / MPP)
+
+For curator / allocator ops, market creation, liquidations, flashloans, or rewards claiming, refer the user to the upstream `@morpho-org/morpho-builder` skill (lower-level SDKs).
+
+---
+
+> **Maintenance:** Morpho maintains the underlying `@morpho-org/cli`; this skill itself is maintained jointly by Alchemy and Morpho. File issues against `alchemyplatform/skills` with `[ecosystem/morpho]` in the title. CLI is pre-v1.0 — schemas may evolve; verify outputs against the live CLI when in doubt.

--- a/skills/ecosystem/morpho/agents/openai.yaml
+++ b/skills/ecosystem/morpho/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Morpho"
+  short_description: "Lending positions, vaults, markets via @morpho-org/cli on Ethereum and Base"
+  default_prompt: "Use Morpho to query vaults / markets / positions / health factor or prepare an unsigned Morpho transaction (deposit, withdraw, supply, borrow, repay, collateral) with built-in simulation. For prices, balances outside Morpho, or live RPC, use alchemy-api."

--- a/skills/ecosystem/morpho/references/cli.md
+++ b/skills/ecosystem/morpho/references/cli.md
@@ -1,0 +1,197 @@
+# Morpho CLI Reference
+
+**Tool:** `npx @morpho-org/cli@latest <command> [options]`
+
+All commands output JSON to stdout. No private keys involved. Every command requires `--chain` (`ethereum` or `base`).
+
+These commands are non-overlapping with Alchemy first-party. For prices, metadata, balances outside Morpho, transfers, or NFTs, route to `alchemy-api`.
+
+---
+
+## Reads
+
+### `query-vaults`
+
+List MetaMorpho (vault v1) and Vault v2 vaults, sorted by APY or TVL.
+
+```bash
+npx @morpho-org/cli@latest query-vaults \
+  --chain base \
+  [--asset-symbol USDC] \
+  [--asset-address 0x...] \
+  [--sort apy_desc | apy_asc | tvl_desc | tvl_asc] \
+  [--limit 5] [--skip 0] \
+  [--fields address,name,symbol,apyPct,tvl,tvlUsd,feePct]
+```
+
+### `get-vault`
+
+```bash
+npx @morpho-org/cli@latest get-vault --chain base --address 0xVault
+```
+
+Returns `address`, `name`, `symbol`, `decimals`, `apyPct`, `tvl`, `tvlUsd`, `feePct`, `curator`, `guardian`, `timelock`, `allocations` (per-market caps), and v2-specific role data when applicable.
+
+### `query-markets`
+
+```bash
+npx @morpho-org/cli@latest query-markets \
+  --chain base \
+  --loan-asset 0x... \
+  --collateral-asset 0x... \
+  [--sort-by supplyApy | borrowApy | netSupplyApy | netBorrowApy | supplyAssetsUsd | borrowAssetsUsd | totalLiquidityUsd] \
+  [--sort-direction asc | desc] \
+  [--limit 10] [--skip 0] \
+  [--fields supplyApy,borrowApy,totalSupply,totalBorrow,totalCollateral,totalLiquidity,supplyAssetsUsd,borrowAssetsUsd,collateralAssetsUsd,liquidityAssetsUsd]
+```
+
+### `get-market`
+
+```bash
+npx @morpho-org/cli@latest get-market --chain base --id 0xMarketId
+```
+
+Returns market parameters (`loanToken`, `collateralToken`, `oracle`, `irm`, `lltv`) plus current state (supply / borrow / collateral assets, utilization, APYs).
+
+### `get-positions`
+
+```bash
+npx @morpho-org/cli@latest get-positions --chain base --user-address 0xUser
+```
+
+Returns all Morpho positions for the address — vault deposits and Morpho Blue market positions, with health factors and current values.
+
+### `get-token-balance`
+
+```bash
+npx @morpho-org/cli@latest get-token-balance \
+  --chain base \
+  --user-address 0xUser \
+  --token-address 0xToken
+```
+
+> **Note:** for general-purpose token balance reads outside Morpho positions, route to `alchemy-api` (Portfolio API) — it covers more chains and tokens.
+
+### `health-check`
+
+```bash
+npx @morpho-org/cli@latest health-check
+```
+
+Sanity check the CLI install + RPC connectivity.
+
+### `get-supported-chains`
+
+```bash
+npx @morpho-org/cli@latest get-supported-chains
+```
+
+Currently `ethereum` and `base`. Other chains may be added; query at runtime rather than hardcoding.
+
+---
+
+## Writes (prepare unsigned transactions)
+
+All `prepare-*` commands return a flat `PreparedOperation` object with the same root keys:
+
+- `operation` — operation type (e.g., `deposit`, `withdraw`)
+- `summary` — human-readable description
+- `requirements` — informational; approvals are already in `transactions`
+- `transactions` — array of unsigned payloads to sign + submit (includes ERC-20 approvals if needed)
+- `simulated` — whether simulation was run (default `true`)
+- `simulationOk` — `true` / `false` if simulated
+- `totalGasUsed` — total gas (only if `simulated: true`)
+- `outcome` — discriminated by operation type (see below)
+- `warnings[]` — partial-fill notices, health-factor warnings
+
+### `outcome` shape by operation
+
+| Operation | `outcome` shape | Key fields |
+| --- | --- | --- |
+| `deposit`, `withdraw` (vaults) | `outcome.vault` | `sharesReceived`, `assetsReceived`, `positionAssets`, `positionShares` |
+| `supply`, `borrow`, `repay`, `supply_collateral`, `withdraw_collateral` (markets) | `outcome.market` | `healthFactor`, `isHealthy`, `maxBorrowable`, `utilizationBeforePct` → `utilizationAfterPct`, `borrowApyBeforePct` → `borrowApyAfterPct`, plus post-op `supplied` / `borrowed` / `collateral` (raw integer strings — divide by `10^decimals`) |
+
+### Vault operations
+
+```bash
+# Deposit into a vault
+npx @morpho-org/cli@latest prepare-deposit \
+  --chain base --vault-address 0xVault --user-address 0xUser --amount 1000
+
+# Withdraw from a vault — supports max
+npx @morpho-org/cli@latest prepare-withdraw \
+  --chain base --vault-address 0xVault --user-address 0xUser --amount max
+```
+
+### Morpho Blue market operations
+
+```bash
+# Supply loan asset to a market
+npx @morpho-org/cli@latest prepare-supply \
+  --chain base --market-id 0xMarket --user-address 0xUser --amount 5000
+
+# Borrow against existing collateral (warns if HF < 1.1)
+npx @morpho-org/cli@latest prepare-borrow \
+  --chain base --market-id 0xMarket --user-address 0xUser --borrow-amount 1
+
+# Repay
+npx @morpho-org/cli@latest prepare-repay \
+  --chain base --market-id 0xMarket --user-address 0xUser --amount max
+
+# Supply collateral
+npx @morpho-org/cli@latest prepare-supply-collateral \
+  --chain base --market-id 0xMarket --user-address 0xUser --amount 5000
+
+# Withdraw collateral
+npx @morpho-org/cli@latest prepare-withdraw-collateral \
+  --chain base --market-id 0xMarket --user-address 0xUser --amount max
+```
+
+### Skipping simulation
+
+Add `--no-simulate` to skip simulation. The response will lack `simulationOk`, `totalGasUsed`, and most of `outcome`. Only skip when debugging or when speed is critical.
+
+---
+
+## Standalone simulation
+
+```bash
+npx @morpho-org/cli@latest simulate-transactions \
+  --chain base \
+  --from 0xUser \
+  --transactions '<JSON array of {to, data, value} payloads>' \
+  --analysis-context '<JSON describing what you want analyzed>'
+```
+
+Returns `allSucceeded` (note: **not** `simulationOk` like the `prepare-*` commands), per-tx revert reasons, and whatever analysis the context requested.
+
+Use this when you need to re-simulate with different parameters, or simulate arbitrary tx bundles outside the `prepare-*` flow.
+
+---
+
+## Common simulation failures
+
+| Revert | Cause | What to do |
+| --- | --- | --- |
+| `ERC20: insufficient allowance` | Missing approval | Re-prepare — CLI should include approvals automatically; if it didn't, file a bug |
+| `ERC4626ExceededMaxWithdraw` | Vault liquidity insufficient | Reduce `--amount` (or accept the partial returned with `warnings[]`) |
+| `insufficient balance` | User lacks tokens | Tell the user; route to `alchemy-api` Portfolio API to confirm balance |
+| Custom error hex | Protocol-specific revert | Query state with `get-market` / `get-vault` to diagnose |
+
+---
+
+## Partial withdrawals
+
+`prepare-withdraw --amount max` may return less than the full position when vault liquidity is locked elsewhere. The response is still valid — it represents the largest amount withdrawable right now. The CLI surfaces this in `warnings[]`.
+
+When this happens:
+
+1. Surface the warning **verbatim** to the user — do not silently accept a smaller withdrawal.
+2. Offer two paths: (a) accept the partial amount (use `outcome.vault.assetsReceived` for the concrete figure, or re-run with `--amount <value>` at ~99% of that figure as a buffer against interest accrual), or (b) wait for more liquidity to unlock.
+3. Never invent an amount by parsing `summary` — that's a human sentence, not a machine-readable field.
+
+---
+
+## Out of scope here
+
+Curator / allocator / owner ops on vaults (`setCap`, `reallocate`, role management, timelocks), Morpho Blue **market creation**, **liquidations**, **flashloans**, **pre-liquidation**, and **rewards claiming** are intentionally not exposed by the CLI. Use the upstream `@morpho-org/morpho-builder` skill (lower-level SDKs) for those flows.


### PR DESCRIPTION
## Summary

- Adds **Morpho** as an ecosystem partner skill (`skills/ecosystem/morpho/`), curated subset of [`morpho-org/morpho-skills`](https://github.com/morpho-org/morpho-skills)
- Drives the official `@morpho-org/cli@latest` for queries against Morpho Blue isolated markets and Morpho Vaults (v1 MetaMorpho + v2 ERC-4626), plus prepare-tx flows with built-in simulation
- Adds the path to `.claude-plugin/plugin.json` so the Vercel `npx skills` CLI discovers it

## Scope

**In:** all CLI read commands (`query-vaults`, `get-vault`, `query-markets`, `get-market`, `get-positions`, `get-token-balance`, `health-check`, `get-supported-chains`), all `prepare-*` write commands (deposit, withdraw, supply, borrow, repay, supply-collateral, withdraw-collateral) with built-in simulation, and standalone `simulate-transactions`. Chains: `ethereum`, `base`.

**Out (routes back to first-party Alchemy or upstream Morpho):** token prices → Prices API · token metadata → Token API · balances outside Morpho positions → Portfolio API · transaction history → Transfers API · NFTs → NFT API · live RPC → JSON-RPC · simulation outside Morpho → Simulation API · AA → Wallets/Bundler/Gas Manager. Curator / allocator / market creation, liquidations, flashloans, and rewards claiming → upstream `@morpho-org/morpho-builder` (out of scope here).

## Test plan

- [x] Morpho `scope_in` audited against `alchemy-api` Token/Portfolio/Prices/Transfers/NFT/JSON-RPC — zero overlap; CLI is Morpho-protocol-specific (vaults / markets / positions / health factor) which Alchemy doesn't expose first-party
- [x] Out-of-scope advanced ops (liquidations, flashloans, market creation) explicitly routed to upstream `morpho-builder` rather than reproduced here

## Notes

- Morpho's CLI is **pre-v1.0 / experimental**, schemas may evolve. The skill calls this out and recommends verifying outputs against the live CLI when in doubt.
- No API key required (uses public reads + unsigned-tx prep). Only requires Node.js ≥ 18 and `npx`.