### PR TITLE
feat(ecosystem): add Chainlink skill (Data Feeds + CCIP)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "alchemy",
   "skills": [
-    "./skills/ecosystem/allium"
+    "./skills/ecosystem/allium",
+    "./skills/ecosystem/chainlink"
   ]
 }

--- a/skills/ecosystem/chainlink/LICENSE.txt
+++ b/skills/ecosystem/chainlink/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chainlink Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ecosystem/chainlink/SKILL.md
+++ b/skills/ecosystem/chainlink/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: chainlink
+description: Read Chainlink Data Feeds (on-chain price feeds via `AggregatorV3Interface`) with the correct safety defaults — staleness checks, `decimals()` lookup, L2 sequencer uptime — and use Chainlink CCIP for cross-chain messaging and programmable token transfers. Covers Data Feeds (price, rates, volatility, SmartData / RWA, MVR bundle, SVR/OEV) and CCIP (sender / receiver contracts, fee estimation, message status, CCT setup). NOT for off-chain spot token prices for valuation, token metadata, current wallet balances, transaction history, or NFT data — for those use `alchemy-cli` (live), `alchemy-mcp`, `alchemy-api` (app code), or `agentic-gateway` (no API key). For non-CCIP cross-chain bridges, use the `lifi` ecosystem skill.
+license: MIT
+compatibility: No Chainlink-specific API key required. Reads use `AggregatorV3Interface` on-chain — transport via `alchemy-api` JSON-RPC (`$ALCHEMY_API_KEY`) or `agentic-gateway`. CCIP writes require user wallet for signing. Optional `@chainlink/mcp-server` MCP tool for SDK-driven monitoring / discovery.
+metadata:
+  author: chainlink
+  version: "0.1"
+  provider: chainlink
+  partner: "true"
+---
+
+# Chainlink (Data Feeds + CCIP)
+
+Chainlink Data Feeds expose on-chain price + rate oracles via `AggregatorV3Interface`. Chainlink CCIP enables cross-chain messages and programmable token transfers between connected chains. This skill covers both surfaces with the safety patterns Chainlink mandates. For off-chain spot prices (portfolio valuation, historical prices), token metadata, balances, transfers, or NFTs, use the corresponding Alchemy skill instead. For non-CCIP cross-chain bridges, use the `lifi` ecosystem skill.
+
+| | |
+| --- | --- |
+| **Data Feeds transport** | On-chain `eth_call` to feed contracts via `alchemy-api` JSON-RPC (or `agentic-gateway` x402/MPP) |
+| **Data Feeds interface** | `AggregatorV3Interface` (`latestRoundData`, `decimals`, `description`, `version`) |
+| **CCIP routers** | Per-chain `Router` contracts; fees via `getFee()`, sends via `ccipSend()` |
+| **MCP (optional)** | `@chainlink/mcp-server` exposes `ccip_sdk` tool for monitoring / discovery |
+| **Safety floor** | Staleness check, dynamic `decimals()`, L2 sequencer uptime, no `answeredInRound` |
+
+## When to use this skill
+
+Use `chainlink` when **any** of the following are true:
+
+- The user wants to **read a Chainlink price feed** on EVM (or Solana / StarkNet / Aptos / Tron)
+- The user wants to **generate a Chainlink consumer contract** with the right safety defaults
+- The user wants **MVR bundle**, **SVR/OEV**, **SmartData/RWA**, **rates**, or **volatility** feeds
+- The user wants to **send a CCIP cross-chain message** or **transfer tokens** via CCIP
+- The user wants to **set up a Cross-Chain Token (CCT)**, configure pools, set rate limits
+- The user wants to **monitor CCIP message status** or check route connectivity
+
+## When NOT to use this skill (handoff)
+
+| Need | Use instead |
+| --- | --- |
+| Off-chain spot token prices for valuation (portfolio totals, USD displays) | `alchemy-api` (Prices API) — aggregates many sources with simpler API |
+| Historical token prices, OHLCV-like intervals | `alchemy-api` (Prices API) |
+| Cross-chain bridges via non-CCIP routes (more bridges, more chains) | `lifi` (ecosystem skill) |
+| Token metadata, search, list by chain | `alchemy-api` (Token API) |
+| Current wallet balances | `alchemy-api` (Portfolio / Token API) |
+| Transaction history (transfers in / out) | `alchemy-api` (Transfers API) |
+| NFT metadata / floor / ownership | `alchemy-api` (NFT API) |
+| Live RPC reads (block #, gas, generic `eth_call`) | `alchemy-cli` (live) or `alchemy-api` (JSON-RPC) |
+| Account abstraction (bundlers, gas managers) | `alchemy-api` |
+| Pre-execution simulation beyond CCIP fee estimation | `alchemy-api` (Simulation API) |
+| Signed transaction submission | the app's wallet / `alchemy-api` |
+
+## Scope contract
+
+**This skill covers (`scope_in`):**
+
+- **Data Feeds:** `AggregatorV3Interface.latestRoundData()` reads with mandatory safety defaults (staleness, dynamic decimals, L2 sequencer uptime), feed-address discovery, MVR bundle feeds, SVR/OEV feeds, SmartData/RWA, rates and volatility feeds, multi-chain (EVM + Solana + StarkNet + Aptos + Tron) feed-reading patterns, consumer contract generation
+- **CCIP:** sender / receiver contracts (Solidity), `Router.ccipSend()`, fee estimation via `getFee()`, programmable token transfers, CCT (Cross-Chain Token) creation and pool setup, rate-limit configuration, route connectivity checks, supported-token discovery, message status / monitoring
+
+**This skill does NOT cover (`scope_out`):**
+
+- Off-chain spot token prices for portfolio valuation → handoff: `alchemy-api` (Prices API). Chainlink Data Feeds are on-chain oracles intended for smart contract consumption; for "what is ETH worth in USD right now in my UI", `alchemy-api` Prices API is the right path.
+- Historical / time-series token prices → handoff: `alchemy-api` (Prices API)
+- Token metadata, balances, transfers, NFT data → handoff: `alchemy-api`
+- General `eth_call` / RPC reads (Chainlink doesn't host the chain) → handoff: `alchemy-api` JSON-RPC (use this transport for Data Feeds reads)
+- Cross-chain bridges via non-CCIP routes → handoff: `lifi` (ecosystem skill)
+- Data Streams (sub-second pull-oracle feeds), CRE / ACE / configurator / deployer skills → out of scope for this curated skill; users who want them can install upstream `smartcontractkit/chainlink-agent-skills` alongside
+- Account abstraction → handoff: `alchemy-api` (Wallets / Bundler / Gas Manager)
+- Pre-execution simulation beyond CCIP fee estimation → handoff: `alchemy-api` (Simulation API)
+- Signed tx submission → user's wallet (CCIP returns calldata; app signs and submits)
+
+## Setup
+
+No Chainlink-specific API key. Reads need an EVM RPC; use `$ALCHEMY_API_KEY`:
+
+```bash
+export ALCHEMY_API_KEY="..."
+```
+
+Optional: install the Chainlink MCP server for `ccip_sdk` tool access from your AI client (Claude Code, Cursor, etc.):
+
+```bash
+npm install -g @chainlink/mcp-server
+# Configure your MCP client to point at it (see Chainlink docs)
+```
+
+## Endpoint reference
+
+### Data Feeds → [references/data-feeds.md](./references/data-feeds.md)
+
+| Surface | Use for |
+| --- | --- |
+| `AggregatorV3Interface.latestRoundData()` | Read latest price + `updatedAt` + `roundId` from a feed contract |
+| `AggregatorV3Interface.decimals()` | Dynamic decimal lookup (never hardcode) |
+| `AggregatorV3Interface.description()` | Feed identifier (e.g., `"ETH / USD"`) |
+| L2 Sequencer Uptime Feed | Mandatory check on Arbitrum / Optimism / Base / Scroll before trusting a feed |
+| MVR `BundleAggregatorProxy` | Multi-variable bundle feeds |
+| SVR / OEV proxies | Smart Value Recapture (MEV recapture) feeds |
+
+### CCIP → [references/ccip.md](./references/ccip.md)
+
+| Surface | Use for |
+| --- | --- |
+| `Router.getFee(...)` | Estimate fee for a cross-chain message before sending |
+| `Router.ccipSend(...)` | Send a cross-chain message (data, tokens, or both) |
+| `IAny2EVMMessageReceiver.ccipReceive(...)` | Receive messages on the destination chain |
+| CCT pool contracts | Programmable token transfers — burn-mint, lock-release, rate-limited |
+| Off-chain message status | Poll via `@chainlink/mcp-server` (`ccip_sdk`) or CCIP Explorer |
+
+## Safety defaults (Data Feeds — non-negotiable)
+
+These MUST be in any consumer contract or read-script generated:
+
+1. **Staleness check** — compare `updatedAt` against a threshold derived from the feed's heartbeat. Never skip.
+2. **Dynamic `decimals()`** — never hardcode. Different feeds use different decimal counts.
+3. **L2 sequencer uptime** — on Arbitrum / Optimism / Base / Scroll / etc., always include a sequencer-uptime check with a grace period after recovery.
+4. **Don't use `answeredInRound`** — deprecated; do not use for freshness validation.
+5. **Mark example code unaudited** — remind users that generated code requires a security review before mainnet.
+
+## Quick examples
+
+### Read ETH/USD on Ethereum (via `alchemy-api` JSON-RPC)
+
+```bash
+# ETH/USD feed: 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419 (Ethereum mainnet)
+curl https://eth-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "eth_call",
+    "params": [{
+      "to":   "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+      "data": "0xfeaf968c"
+    }, "latest"]
+  }'
+# Selector 0xfeaf968c = latestRoundData()
+# Returns: (roundId, answer, startedAt, updatedAt, answeredInRound) ABI-encoded
+# Always also call decimals() (selector 0x313ce567) to scale `answer` correctly
+```
+
+### Generate a Solidity consumer (with safety defaults baked in)
+
+See [references/data-feeds.md](./references/data-feeds.md) for the canonical Solidity template — staleness check, `decimals()` call, L2 sequencer-uptime check, and the inline comment block flagging that the example is unaudited.
+
+### Estimate a CCIP fee + send a cross-chain message
+
+See [references/ccip.md](./references/ccip.md) for sender contract patterns, `Router.getFee` calldata construction, and the approval protocol Chainlink recommends before any on-chain CCIP action.
+
+## Common gotchas
+
+- **Hardcoded decimals are a bug**: ETH/USD is 8 decimals on most chains, but rates feeds (e.g., stETH/ETH) are 18. Always call `decimals()`.
+- **Staleness varies by feed**: BTC/USD heartbeat ≈ 1 hour; less-liquid pairs can be 24 hours. The skill recommends `block.timestamp - updatedAt < 2 * heartbeat` as a starting threshold; tune per feed.
+- **`answeredInRound`** is deprecated — do not use for freshness validation.
+- **L2 sequencer feeds are separate addresses** from the price feeds. Skipping them on L2 chains is unsafe — the price feed will keep returning stale data while the L2 sequencer is down.
+- **Mainnet writes via CCIP**: this skill's scope_in includes contract generation and fee estimation, but the upstream skill refuses mainnet write actions in v0. Treat any `ccipSend` to mainnet as testnet-first; require explicit user approval for any on-chain action.
+- **Off-chain prices ≠ on-chain feed**: an `alchemy-api` Prices API quote is fine for "show ETH = $3,200 in the UI". A Chainlink Data Feed read is needed when a **smart contract** decides whether to liquidate based on the price — the on-chain oracle is the source of truth for on-chain logic.
+- **Non-EVM chains**: Solana, Aptos, StarkNet, and Tron have different feed-access patterns — see [references/data-feeds.md](./references/data-feeds.md) for chain-specific guidance.
+
+## Routing back to Alchemy
+
+If during a session the user's need shifts to surfaces this skill doesn't cover:
+
+- For **off-chain prices for valuation / display**: `alchemy-api` (Prices API)
+- For **token metadata, balances, transfer history, NFTs**: `alchemy-api`
+- For **generic JSON-RPC or live debugging**: `alchemy-cli` (live) or `alchemy-api`
+- For **app code without an API key**: `agentic-gateway`
+- For **non-CCIP cross-chain bridges**: `lifi` (ecosystem skill)
+
+The actual transport for Data Feeds reads (`eth_call` to `AggregatorV3Interface`) is `alchemy-api` JSON-RPC — Chainlink's value is the *what to call and how to interpret it* layer, not RPC hosting.
+
+---
+
+> **Maintenance:** Chainlink Labs maintains the underlying contracts and SDKs; this skill itself is maintained jointly by Alchemy and Chainlink Labs. File issues against `alchemyplatform/skills` with `[ecosystem/chainlink]` in the title. Data Streams, CRE, ACE, and configurator/deployer skills from upstream are intentionally not mirrored here — install `smartcontractkit/chainlink-agent-skills` alongside if you need them.

--- a/skills/ecosystem/chainlink/agents/openai.yaml
+++ b/skills/ecosystem/chainlink/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Chainlink"
+  short_description: "On-chain Chainlink Data Feeds (with safety defaults) and CCIP cross-chain messaging"
+  default_prompt: "Use Chainlink to read on-chain Data Feeds with the right safety defaults (staleness check, dynamic decimals, L2 sequencer uptime), or to send / receive CCIP cross-chain messages and programmable token transfers. For off-chain spot prices, balances, or transaction history, use alchemy-api. For non-CCIP bridges, use lifi."

--- a/skills/ecosystem/chainlink/references/ccip.md
+++ b/skills/ecosystem/chainlink/references/ccip.md
@@ -1,0 +1,201 @@
+# Chainlink CCIP Reference
+
+CCIP (Cross-Chain Interoperability Protocol) is Chainlink's cross-chain messaging + token-transfer layer. It powers messages, programmable token transfers, and CCT (Cross-Chain Token) deployments across connected chains.
+
+These flows are non-overlapping with Alchemy first-party. For non-CCIP bridges (more chains, more bridges), route to the `lifi` ecosystem skill.
+
+---
+
+## Architecture (one paragraph)
+
+A `Router` contract on the source chain accepts a CCIP message and forwards it (after fee payment) to an off-chain DON, which delivers it to a `Router` on the destination chain. The destination Router calls `ccipReceive(...)` on the receiver contract. Token transfers piggyback on the same message via `tokenAmounts[]`.
+
+---
+
+## Approval protocol (Chainlink-mandated)
+
+Before **any** on-chain CCIP action (send / bridge / deploy / register), present a preflight summary to the user:
+
+```text
+Proposed on-chain action:
+- Action:           ccipSend
+- Network:          testnet
+- Source chain:     Sepolia (chainSelector 16015286601757825753)
+- Destination:      Base Sepolia (chainSelector 10344971235874465080)
+- Route/lane:       sepolia → base-sepolia (active)
+- Token/amount:     1.0 LINK
+- Payload:          0x... (32 bytes)
+- Contracts:        Router 0x..., Receiver 0x...
+- Method:           Router.ccipSend(destinationChainSelector, message)
+- Expected effect:  Message delivered to receiver on Base Sepolia within ~10min;
+                    1.0 LINK debited from sender on Sepolia, credited on Base Sepolia.
+
+Do you want me to execute this?
+```
+
+For testnet sends, **require a second explicit confirmation** immediately before execution. Refuse all mainnet write actions in this skill version (read-only mainnet lookups are fine).
+
+---
+
+## Sender contract (canonical pattern)
+
+```solidity
+// SPDX-License-Identifier: MIT
+// UNAUDITED — review before mainnet use.
+pragma solidity ^0.8.20;
+
+import { IRouterClient } from "@chainlink/contracts-ccip/contracts/interfaces/IRouterClient.sol";
+import { Client }        from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
+import { IERC20 }        from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract Sender {
+    IRouterClient public immutable router;
+    IERC20        public immutable feeToken; // e.g., LINK
+
+    error InsufficientFee(uint256 fee, uint256 balance);
+
+    constructor(address _router, address _feeToken) {
+        router   = IRouterClient(_router);
+        feeToken = IERC20(_feeToken);
+    }
+
+    function send(
+        uint64  destChainSelector,
+        address receiver,
+        bytes memory data,
+        Client.EVMTokenAmount[] memory tokenAmounts
+    ) external returns (bytes32 messageId) {
+        Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+            receiver:     abi.encode(receiver),
+            data:         data,
+            tokenAmounts: tokenAmounts,
+            extraArgs:    Client._argsToBytes(Client.EVMExtraArgsV2({
+                              gasLimit:        200_000,
+                              allowOutOfOrderExecution: true
+                          })),
+            feeToken:     address(feeToken)
+        });
+
+        uint256 fee = router.getFee(destChainSelector, message);
+        uint256 bal = feeToken.balanceOf(address(this));
+        if (bal < fee) revert InsufficientFee(fee, bal);
+
+        feeToken.approve(address(router), fee);
+        messageId = router.ccipSend(destChainSelector, message);
+    }
+}
+```
+
+### Notes
+
+- `destChainSelector` is the **CCIP chain selector** (uint64), not the EVM chain ID. Look up at [CCIP directory](https://docs.chain.link/ccip/directory).
+- `feeToken` can be `address(0)` for native gas token, or LINK / wrapped native for ERC-20 fees.
+- `extraArgs` carries `gasLimit` for the destination `ccipReceive` call. Tune per destination receiver complexity.
+- `allowOutOfOrderExecution: true` is required by recent CCIP versions for non-blocking lanes.
+
+---
+
+## Receiver contract (canonical pattern)
+
+```solidity
+// SPDX-License-Identifier: MIT
+// UNAUDITED — review before mainnet use.
+pragma solidity ^0.8.20;
+
+import { CCIPReceiver } from "@chainlink/contracts-ccip/contracts/applications/CCIPReceiver.sol";
+import { Client }       from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
+
+contract Receiver is CCIPReceiver {
+    error UnexpectedSourceChain(uint64 chainSelector);
+    error UnexpectedSender(address sender);
+
+    uint64  public immutable expectedSourceChainSelector;
+    address public immutable expectedSender;
+
+    constructor(address _router, uint64 _sourceSelector, address _sender)
+        CCIPReceiver(_router)
+    {
+        expectedSourceChainSelector = _sourceSelector;
+        expectedSender              = _sender;
+    }
+
+    function _ccipReceive(Client.Any2EVMMessage memory message) internal override {
+        // Source-chain validation
+        if (message.sourceChainSelector != expectedSourceChainSelector) {
+            revert UnexpectedSourceChain(message.sourceChainSelector);
+        }
+
+        // Sender validation (sender is abi-encoded address)
+        address actualSender = abi.decode(message.sender, (address));
+        if (actualSender != expectedSender) revert UnexpectedSender(actualSender);
+
+        // Process message.data and message.destTokenAmounts...
+    }
+}
+```
+
+### Defensive receiver checklist
+
+- Validate `sourceChainSelector` against your expected source.
+- Validate the abi-decoded `sender` against your expected counterparty.
+- Use access control on any business-logic methods invoked by `_ccipReceive`.
+- Don't let untrusted callers call `ccipReceive` directly — `CCIPReceiver` already enforces `onlyRouter`, but custom receivers must too.
+
+---
+
+## Fee estimation off-chain
+
+Use `Router.getFee(...)` from a script before constructing the on-chain `ccipSend` to avoid surprise reverts:
+
+```bash
+# Source chain Router on Sepolia: 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
+# Encode the EVM2AnyMessage struct (use ethers / viem; raw curl is impractical here)
+# Then call getFee(destChainSelector, message)
+```
+
+For agent-driven workflows where the `@chainlink/mcp-server` MCP tool is available, prefer `ccip_sdk.getFee(...)` over hand-rolling the calldata.
+
+---
+
+## Programmable token transfers (CCT)
+
+CCT (Cross-Chain Tokens) are tokens with first-class CCIP integration. Pool contracts on each chain handle the token's cross-chain semantics:
+
+- **Burn-mint pools** — burn on source, mint on destination (canonical for newly-bridged tokens)
+- **Lock-release pools** — lock on source, release on destination (canonical for existing tokens with fixed supply)
+- **Rate-limited pools** — cap throughput per epoch to limit blast radius
+
+CCT setup is a multi-step flow:
+
+1. Deploy the token on each chain (or use existing).
+2. Deploy a pool contract per chain (`BurnMintTokenPool` / `LockReleaseTokenPool`).
+3. Register the token + pools with CCIP via the `TokenAdminRegistry`.
+4. Configure rate limits per lane.
+5. Test on testnet before enabling mainnet lanes.
+
+For step-by-step CCT setup, refer to [CCT Setup docs](https://docs.chain.link/ccip/concepts/cross-chain-tokens). This skill's scope_in includes generating pool / setup contracts; mainnet enable / register actions still require the upstream `smartcontractkit/chainlink-agent-skills` repo for current production behavior.
+
+---
+
+## Monitoring + status
+
+```text
+PENDING:    message accepted on source, awaiting DON delivery
+SUCCESS:    message delivered + ccipReceive succeeded
+FAILED:     ccipReceive reverted (delivered, but the receiver failed)
+```
+
+Where to look:
+
+- **CCIP Explorer** — https://ccip.chain.link/ (web UI; copy a tx hash or messageId)
+- **`@chainlink/mcp-server`** — `ccip_sdk` MCP tool exposes `getMessageStatus`, `listLanes`, `listSupportedTokens`
+- **On-chain events** — `OffRamp.ExecutionStateChanged(messageId, state)` on the destination chain
+
+---
+
+## Out of scope here
+
+- **Data Streams** — Chainlink's sub-second pull-oracle product (separate from Data Feeds). Install upstream `smartcontractkit/chainlink-agent-skills` if you need it.
+- **CRE / ACE / configurator / deployer** — Chainlink Runtime Environment skills.
+- **Mainnet writes via this skill** — refused per safety guardrails. Refer users to the upstream skill for current mainnet write workflows; testnet writes are allowed with the approval protocol above.
+- **Non-CCIP cross-chain bridges** — for users who want broader bridge coverage (27 bridges across 60+ chains), route to `lifi`.

--- a/skills/ecosystem/chainlink/references/data-feeds.md
+++ b/skills/ecosystem/chainlink/references/data-feeds.md
@@ -1,0 +1,194 @@
+# Chainlink Data Feeds Reference
+
+**Transport:** on-chain `eth_call` via `alchemy-api` JSON-RPC (or `agentic-gateway`). Chainlink doesn't host RPC; this skill provides the contract addresses, ABI, and safety patterns.
+
+For off-chain spot prices for portfolio valuation or UI display, route to `alchemy-api` (Prices API) instead — Chainlink Data Feeds are oracle reads intended for **smart contract consumption**, not for off-chain valuation.
+
+---
+
+## `AggregatorV3Interface`
+
+The standard interface every Chainlink Data Feed implements:
+
+```solidity
+interface AggregatorV3Interface {
+  function decimals() external view returns (uint8);
+  function description() external view returns (string memory);
+  function version() external view returns (uint256);
+
+  function latestRoundData() external view returns (
+    uint80  roundId,
+    int256  answer,
+    uint256 startedAt,
+    uint256 updatedAt,
+    uint80  answeredInRound  // DEPRECATED — do not use
+  );
+
+  function getRoundData(uint80 _roundId) external view returns (
+    uint80  roundId,
+    int256  answer,
+    uint256 startedAt,
+    uint256 updatedAt,
+    uint80  answeredInRound
+  );
+}
+```
+
+Function selectors (for direct `eth_call`):
+
+- `decimals()` → `0x313ce567`
+- `description()` → `0x7284e416`
+- `version()` → `0x54fd4d50`
+- `latestRoundData()` → `0xfeaf968c`
+- `getRoundData(uint80)` → `0x9a6fc8f5`
+
+---
+
+## Reading a feed off-chain (via `alchemy-api`)
+
+```bash
+# 1. Look up the feed address for your chain + pair
+#    (e.g., ETH/USD on Ethereum mainnet: 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419)
+#    Source: https://docs.chain.link/data-feeds/price-feeds/addresses
+
+# 2. Call latestRoundData()
+curl https://eth-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY \
+  -H "Content-Type: application/json" \
+  -d '{ "jsonrpc": "2.0", "id": 1, "method": "eth_call",
+        "params": [{ "to": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+                     "data": "0xfeaf968c" }, "latest"] }'
+
+# 3. Decode (ABI: roundId uint80, answer int256, startedAt uint256, updatedAt uint256, answeredInRound uint80)
+
+# 4. Always also call decimals() and validate updatedAt against the feed's heartbeat
+curl https://eth-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY \
+  -H "Content-Type: application/json" \
+  -d '{ "jsonrpc": "2.0", "id": 2, "method": "eth_call",
+        "params": [{ "to": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+                     "data": "0x313ce567" }, "latest"] }'
+```
+
+---
+
+## Solidity consumer (canonical pattern)
+
+```solidity
+// SPDX-License-Identifier: MIT
+// UNAUDITED — review before mainnet use.
+pragma solidity ^0.8.20;
+
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+
+contract PriceConsumer {
+    AggregatorV3Interface public immutable feed;
+
+    /// Heartbeat in seconds for the specific feed (look this up in Chainlink docs).
+    /// e.g., ETH/USD on mainnet ≈ 3600 (1 hour); less-liquid pairs may be 86400 (24 hours).
+    uint256 public immutable heartbeat;
+
+    /// Tolerated staleness window (typically 1.5x – 2x heartbeat).
+    uint256 public immutable staleAfter;
+
+    error PriceStale(uint256 updatedAt, uint256 staleAfter);
+    error InvalidPrice(int256 answer);
+
+    constructor(address _feed, uint256 _heartbeat) {
+        feed       = AggregatorV3Interface(_feed);
+        heartbeat  = _heartbeat;
+        staleAfter = _heartbeat * 2;
+    }
+
+    /// Returns price scaled to the feed's reported decimals.
+    function latestPrice() public view returns (int256 answer, uint8 decimals_) {
+        (, int256 _answer,, uint256 _updatedAt,) = feed.latestRoundData();
+
+        // Mandatory: staleness check
+        if (block.timestamp - _updatedAt > staleAfter) {
+            revert PriceStale(_updatedAt, staleAfter);
+        }
+
+        // Mandatory: invalid-price check
+        if (_answer <= 0) revert InvalidPrice(_answer);
+
+        // Mandatory: dynamic decimals
+        decimals_ = feed.decimals();
+        return (_answer, decimals_);
+    }
+}
+```
+
+### L2 sequencer uptime addition (Arbitrum / Optimism / Base / Scroll / etc.)
+
+```solidity
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+
+AggregatorV3Interface public immutable sequencerUptimeFeed;
+uint256 public constant GRACE_PERIOD = 3600; // 1 hour after sequencer recovery
+
+error SequencerDown();
+error GracePeriodNotOver(uint256 startedAt, uint256 graceEnds);
+
+function _requireSequencerUp() internal view {
+    (, int256 sequencerStatus, uint256 startedAt,,) = sequencerUptimeFeed.latestRoundData();
+
+    // 0 = up, 1 = down
+    if (sequencerStatus == 1) revert SequencerDown();
+
+    // Even if up, wait for the grace period after recovery
+    if (block.timestamp - startedAt <= GRACE_PERIOD) {
+        revert GracePeriodNotOver(startedAt, startedAt + GRACE_PERIOD);
+    }
+}
+```
+
+Sequencer Uptime Feed addresses (look up at https://docs.chain.link/data-feeds/l2-sequencer-feeds):
+- Arbitrum One: `0xFdB631F5EE196F0ed6FAa767959853A9F217697D`
+- Optimism: `0x371EAD81c9102C9BF4874A9075FFFf170F2Ee389`
+- Base: `0xBCF85224fc0756B9Fa45aA7892530B47e10b6433`
+- Scroll: `0x45c2b8C204568A03Dc7A2E32B71D67Fe97F908A9`
+
+---
+
+## Feed types
+
+| Type | Use for | Reference doc |
+| --- | --- | --- |
+| Standard price feeds | Token / fiat / commodity prices | [Price Feed addresses](https://docs.chain.link/data-feeds/price-feeds/addresses) |
+| **MVR (Multi-Variable Response) bundle feeds** | Multi-asset bundles via `BundleAggregatorProxy` | [MVR Feeds](https://docs.chain.link/data-feeds/mvr-feeds) |
+| **SVR / OEV feeds** | Smart Value Recapture / OEV recapture | [SVR Feeds](https://docs.chain.link/data-feeds/svr) |
+| **SmartData / RWA feeds** | NAV, reserves, tokenized equity (e.g., USDM, AUSD) | [SmartData](https://docs.chain.link/data-feeds/smartdata) |
+| **Rates & Volatility feeds** | Interest rates (`stETH/ETH`, `eUSD/USD`), realized volatility | [Rates & Vol](https://docs.chain.link/data-feeds/rates-feeds) |
+| **L2 Sequencer Uptime feeds** | L2 health gating | [L2 Sequencer Feeds](https://docs.chain.link/data-feeds/l2-sequencer-feeds) |
+
+---
+
+## Safety defaults (non-negotiable)
+
+Every consumer contract or read script must:
+
+1. **Validate `updatedAt` against a staleness threshold** (typically `2 * heartbeat`). Reject reads where `block.timestamp - updatedAt > staleAfter`.
+2. **Call `decimals()` dynamically** — never hardcode (different feeds have different decimal counts).
+3. **On L2 chains**, include the L2 Sequencer Uptime check with a grace period after recovery.
+4. **Reject `answer <= 0`** as invalid.
+5. **Do not use `answeredInRound`** — deprecated. The current freshness validator is `updatedAt`.
+6. **Mark example code as unaudited** — remind users to commission a security review before mainnet.
+
+---
+
+## Multi-chain (non-EVM)
+
+Chainlink Data Feeds are also available on Solana, Aptos, StarkNet, and Tron — with chain-specific access patterns (e.g., reading via Solana SDK, not `eth_call`). For non-EVM feed access, refer to:
+
+- [Solana feeds](https://docs.chain.link/data-feeds/solana)
+- [Aptos feeds](https://docs.chain.link/data-feeds/aptos)
+- [StarkNet feeds](https://docs.chain.link/data-feeds/starknet)
+- [Tron feeds](https://docs.chain.link/data-feeds/tron)
+
+For Solana specifically, route reads through `alchemy-api` Solana RPC; the feed-account layout differs from EVM AggregatorV3Interface.
+
+---
+
+## Out of scope here
+
+- **Data Streams** (Chainlink's sub-second pull-oracle product) — different access pattern (off-chain HTTP API + on-chain verifier contract). Install upstream `smartcontractkit/chainlink-agent-skills` if you need this.
+- **CRE / ACE / configurator / deployer** — Chainlink Runtime Environment skills; out of scope for this curated skill.


### PR DESCRIPTION
## Summary

- Adds **Chainlink** as an ecosystem partner skill (`skills/ecosystem/chainlink/`), curated subset of [`smartcontractkit/chainlink-agent-skills`](https://github.com/smartcontractkit/chainlink-agent-skills)
- Focused on the two most-used Chainlink surfaces: **on-chain Data Feeds** reads (with safety defaults Chainlink mandates) and **CCIP** cross-chain messaging + programmable token transfers
- Adds the path to `.claude-plugin/plugin.json` so the Vercel `npx skills` CLI discovers it

## Scope

**In:**
- **Data Feeds:** `AggregatorV3Interface` reads, staleness validation, dynamic `decimals()`, L2 sequencer uptime gating, MVR / SVR-OEV / SmartData-RWA / rates / volatility feeds, multi-chain (EVM + Solana + StarkNet + Aptos + Tron) pointers, Solidity consumer contract generation
- **CCIP:** sender / receiver patterns, `Router.getFee` + `Router.ccipSend`, programmable token transfers, CCT setup pointers, message status / monitoring

**Out (routes back to first-party Alchemy or other ecosystem skills):**
- off-chain spot prices for valuation → `alchemy-api` (Prices API). **Important framing:** Chainlink Data Feeds are oracle reads intended for smart-contract consumption; for "what is ETH worth in USD in my UI", `alchemy-api` Prices API is the right path. The skill calls this distinction out explicitly to prevent mis-routing.
- token metadata, balances, transfers, NFTs → `alchemy-api`
- generic JSON-RPC → `alchemy-api` JSON-RPC (also used as the transport for Data Feeds `eth_call` — Chainlink doesn't host RPC)
- non-CCIP cross-chain bridges → `lifi` (more bridges, more chains)
- AA → Wallets / Bundler / Gas Manager
- pre-execution simulation beyond CCIP fee estimation → Simulation API

## Safety defaults baked in

The skill enforces (and the canonical Solidity template demonstrates):

1. Staleness validation against feed heartbeat
2. Dynamic `decimals()` lookup (never hardcode)
3. L2 sequencer uptime check with grace period (Arbitrum / Optimism / Base / Scroll)
4. Reject `answer <= 0`
5. **Don't use `answeredInRound`** (deprecated)
6. Mark generated example code as unaudited

Mainnet writes are **refused** in this version per Chainlink's own guardrails; testnet writes require a two-step approval protocol. The skill calls this out in the SKILL.md.

## Test plan

- [x] Chainlink `scope_in` audited against `alchemy-api` — partial overlap with Prices API on token prices specifically; resolved by scoping Data Feeds to **on-chain consumption** and routing off-chain valuation explicitly to `alchemy-api`
- [x] CCIP scope clearly separated from generic bridging (which routes to `lifi`)