### PR TITLE
feat(ecosystem): add MoonPay skill (fiat ramps + payments + swap/bridge + automation)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "alchemy",
   "skills": [
-    "./skills/ecosystem/allium"
+    "./skills/ecosystem/allium",
+    "./skills/ecosystem/moonpay"
   ]
 }

--- a/skills/ecosystem/moonpay/LICENSE.txt
+++ b/skills/ecosystem/moonpay/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MoonPay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ecosystem/moonpay/SKILL.md
+++ b/skills/ecosystem/moonpay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moonpay
-description: Buy crypto with fiat (credit card / bank), set up a fiat on/off-ramp virtual account (KYC + USD / EUR ↔ USDC / USDT / EURC across Solana, Ethereum, Polygon, Base, Arbitrum), accept crypto payments via multi-chain deposit links that auto-convert to stablecoins, and shop on Solana Pay-enabled Shopify stores — all via MoonPay's `mp` CLI. NOT for token swaps, token metadata, current wallet balances, transaction history, NFT data, or live RPC reads — for those use `alchemy-cli` (live), `alchemy-mcp`, `alchemy-api` (app code), or `agentic-gateway` (no API key). For pure cross-chain token swaps, use the `lifi` ecosystem skill.
+description: Buy crypto with fiat, set up fiat on/off-ramp virtual accounts (KYC + USD/EUR ↔ USDC/USDT/EURC on Solana, Ethereum, Polygon, Base, Arbitrum), accept crypto via multi-chain deposit links that auto-convert to stablecoins, swap and bridge tokens (same-chain + cross-chain via swaps.xyz), shop on Solana Pay Shopify stores, and automate DCA / limit-order / stop-loss strategies via cron or launchd — all via the `mp` CLI. NOT for token metadata, balances, transaction history, NFT data, or live RPC reads — for those use `alchemy-cli` (live), `alchemy-mcp`, `alchemy-api` (app code), or `agentic-gateway` (no API key).
 license: MIT
 compatibility: Requires the MoonPay `mp` CLI (install per MoonPay docs). No Alchemy API key needed — reads + payment flows go through MoonPay's hosted infrastructure. KYC and user verification handled by MoonPay's checkout / virtual-account flows. Network access required.
 metadata:
@@ -10,9 +10,9 @@ metadata:
   partner: "true"
 ---
 
-# MoonPay (Fiat On/Off-Ramps + Payments)
+# MoonPay (Fiat Ramps + Payments + Swap/Bridge + Automation)
 
-MoonPay provides fiat-to-crypto on-ramps, crypto-to-fiat off-ramps, multi-chain crypto deposit infrastructure, and crypto checkout for Solana Pay-enabled Shopify stores. This skill covers those four payment-flow surfaces via the official `mp` CLI. For token swaps, balances, prices, transaction history, NFT data, or live RPC, use the corresponding Alchemy skill instead.
+MoonPay provides fiat-to-crypto on-ramps, crypto-to-fiat off-ramps, multi-chain crypto deposit infrastructure, Solana Pay checkout for Shopify stores, same-chain swaps + cross-chain bridges (via swaps.xyz), and trading automation (DCA / limit orders / stop losses via cron or launchd). This skill covers all six surfaces via the official `mp` CLI. For balances, prices, transaction history, NFT data, or live RPC, use the corresponding Alchemy skill instead.
 
 | | |
 | --- | --- |
@@ -30,12 +30,13 @@ Use `moonpay` when **any** of the following are true:
 - The user wants to **set up a fiat on/off-ramp virtual account** (USD or EUR ↔ stablecoins, with KYC + bank-account registration)
 - The user wants to **accept crypto payments** via multi-chain deposit links that auto-convert to stablecoins
 - The user wants to **pay for goods on a Solana Pay-enabled Shopify store** with crypto
+- The user wants to **swap or bridge tokens** (same-chain or cross-chain) via the MoonPay CLI
+- The user wants to **automate trading** (DCA, limit order, stop loss) via cron / launchd
 
 ## When NOT to use this skill (handoff)
 
 | Need | Use instead |
 | --- | --- |
-| Token swaps (DEX / cross-chain bridge) | `lifi` (ecosystem skill) — broader bridge / DEX coverage |
 | Token prices (current, historical) | `alchemy-api` (Prices API) |
 | Token metadata, search, list by chain | `alchemy-api` (Token API) |
 | Current wallet balances | `alchemy-api` (Portfolio / Token API) |
@@ -55,10 +56,11 @@ Use `moonpay` when **any** of the following are true:
 - **Virtual account** (`mp virtual-account *`) — full fiat on/off-ramp: KYC, agreement acceptance, wallet registration, bank-account registration (ACH / SEPA / etc.), onramp creation (fiat → stablecoin), offramp creation (stablecoin → fiat), payment / settlement flows.
 - **Multi-chain deposits** (`mp deposit *`) — permissionless deposit links that generate addresses on Solana / Ethereum / Bitcoin / Tron and auto-convert incoming crypto to a chosen stablecoin (USDC / USDT) on the destination chain.
 - **Commerce** (`mp commerce *`) — browse Solana Pay-enabled Shopify stores, search products, manage cart, checkout with crypto (USDC) via Helio integration.
+- **Swap & bridge** (`mp token swap` / `mp token bridge`) — same-chain swaps + cross-chain bridges via swaps.xyz across Solana, Ethereum, Base, Polygon, Arbitrum, Optimism, BNB, Avalanche, Bitcoin (bridges only). Auto-handles ERC-20 approvals; signs locally and broadcasts.
+- **Trading automation** — shell-script + cron / launchd patterns composing `mp token swap` and `mp token search` for DCA, limit orders, and stop losses. Self-disabling for one-shot triggers (limit / stop). Logs to `~/.config/moonpay/logs/trading.log`.
 
 **This skill does NOT cover (`scope_out`):**
 
-- Token swaps (DEX or cross-chain) → handoff: `lifi` (ecosystem skill). MoonPay's upstream `moonpay-swap-tokens` overlaps with `lifi`; we route to `lifi` for broader coverage.
 - Token prices for valuation → handoff: `alchemy-api` (Prices API)
 - Token metadata, list, search → handoff: `alchemy-api` (Token API). Not the upstream `moonpay-discover-tokens`.
 - Wallet balances → handoff: `alchemy-api` (Portfolio / Token API). Not the upstream `moonpay-check-wallet`.
@@ -68,7 +70,7 @@ Use `moonpay` when **any** of the following are true:
 - Wallet auth, hardware wallet integration → handoff: `alchemy-api` (Wallets / Account Kit). Not the upstream `moonpay-auth` / `moonpay-hardware-wallet`.
 - x402 / autonomous-agent payments → handoff: `agentic-gateway`. Not the upstream `moonpay-x402`.
 - Account abstraction → handoff: `alchemy-api`
-- Trading automation, prediction markets, price alerts, internal CLI features → out of scope here. Install `moonpay/skills` upstream alongside if you need them.
+- Prediction markets, price alerts, internal CLI features (mcp, scout, missions, statusline, feedback, upgrade, export-data) → out of scope here. Install `moonpay/skills` upstream alongside if you need them.
 
 ## Setup
 
@@ -119,6 +121,29 @@ Supported destination chains: `solana`, `ethereum`, `base`, `polygon`, `arbitrum
 | `mp commerce product retrieve --store <s> --productId <id>` | Product details |
 | `mp commerce cart {add,retrieve,remove}` | Cart management |
 | `mp commerce checkout ...` | Sign + submit Solana Pay payment via Helio (gas paid by Helio) |
+
+### `mp token *` — same-chain swap + cross-chain bridge
+
+| Command | Use for |
+| --- | --- |
+| `mp token swap --wallet <w> --chain <c> --from-token <addr> --from-amount <n> --to-token <addr>` | Same-chain swap via swaps.xyz; auto-approves ERC-20 if needed. Supports `--to-amount` for exact-out. |
+| `mp token bridge --from-wallet <w> --from-chain <c> --from-token <addr> --from-amount <n> --to-chain <c> --to-token <addr>` | Cross-chain bridge via swaps.xyz; signs + broadcasts locally. |
+| `mp token search --query <q> --chain <c>` | Resolve token names → addresses (use before swap/bridge if user provides symbols). |
+| `mp token balance list --wallet <addr> --chain <c>` | Check balances pre-swap. |
+
+Supported chains: `solana`, `ethereum`, `base`, `polygon`, `arbitrum`, `optimism`, `bnb`, `avalanche`, `bitcoin` (bridges only).
+
+### Trading automation — `mp` + cron / launchd
+
+Generates shell scripts at `~/.config/moonpay/scripts/` that compose `mp token swap` (and `mp token search` for price reads) on a schedule. Logs to `~/.config/moonpay/logs/trading.log`.
+
+| Strategy | Script pattern |
+| --- | --- |
+| **DCA** | Run `mp token swap` on cron / launchd at fixed intervals (e.g., `0 9 * * *` for daily). |
+| **Limit order** | Poll price every 5 min via `mp token search`; execute swap when below target; self-disable after fill. |
+| **Stop loss** | Poll price every 5 min; query balance via `mp token balance list`; sell entire balance when below trigger; self-disable after fill. |
+
+See `references/cli.md` for full script templates (cron + launchd plist) and the self-disable patterns.
 
 ## Quick examples
 
@@ -172,6 +197,31 @@ mp commerce checkout \
   --address "123 Main St" --city Amsterdam --postalCode 1011 --country Netherlands
 ```
 
+### Same-chain swap (SOL → USDC on Solana)
+
+```bash
+mp token swap \
+  --wallet main --chain solana \
+  --from-token So11111111111111111111111111111111111111111 \
+  --from-amount 0.1 \
+  --to-token EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+```
+
+### Cross-chain bridge (ETH on Ethereum → USDC.e on Polygon)
+
+```bash
+mp token bridge \
+  --from-wallet funded --from-chain ethereum \
+  --from-token 0x0000000000000000000000000000000000000000 \
+  --from-amount 0.003 \
+  --to-chain polygon \
+  --to-token 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174
+```
+
+### DCA — buy $5 of SOL daily at 9am
+
+Generate a script at `~/.config/moonpay/scripts/dca-sol.sh` that calls `mp token swap`, then schedule with cron (`0 9 * * *`) or launchd. Full pattern (incl. logging + macOS launchd plist) in [references/cli.md](./references/cli.md).
+
 ## Common gotchas
 
 - **`--token` uses MoonPay codes**, not contract addresses or mint addresses (e.g., `usdc_base`, not the contract). See `references/cli.md` for the supported token list.
@@ -181,17 +231,18 @@ mp commerce checkout \
 - **Commerce is Solana-only** for payment today, even if the store is multi-chain. The buyer pays in USDC on Solana.
 - **Deposit destination chains** are `solana / ethereum / base / polygon / arbitrum / bnb`; sender chains are `solana / ethereum / bitcoin / tron`.
 - **Helio infrastructure** powers the deposit + commerce flows under the hood. The buyer doesn't pay gas for commerce checkouts (Helio sponsors).
+- **Native-token addresses for swap/bridge**: EVM chains use `0x0000000000000000000000000000000000000000`; Solana uses `So11111111111111111111111111111111111111111`.
+- **swaps.xyz** is the routing engine behind `mp token swap` / `bridge`. ERC-20 approvals are sent automatically as a separate tx before the swap — expect 2 transactions for first-time approvals.
+- **Trading automation requires the user session to be active** for OS keychain access. Don't schedule trades on a machine that locks aggressively. macOS launchd fires even after sleep; cron does not.
 
 ## Routing back to Alchemy
 
-If during a session the user's need shifts to surfaces this skill doesn't cover (token swaps, balances, prices, transaction history, NFT data, live RPC), hand off:
+If during a session the user's need shifts to surfaces this skill doesn't cover (balances, prices, transaction history, NFT data, live RPC), hand off:
 
 - `alchemy-cli` — live agent work in the current session via the local CLI
 - `alchemy-mcp` — live work via the hosted MCP server when CLI is not installed
 - `alchemy-api` — application code with an Alchemy API key
 - `agentic-gateway` — application code without an API key (x402 / MPP)
-
-For pure cross-chain token swaps (no fiat involved), hand off to the `lifi` ecosystem skill.
 
 ---
 

--- a/skills/ecosystem/moonpay/SKILL.md
+++ b/skills/ecosystem/moonpay/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: moonpay
+description: Buy crypto with fiat (credit card / bank), set up a fiat on/off-ramp virtual account (KYC + USD / EUR ↔ USDC / USDT / EURC across Solana, Ethereum, Polygon, Base, Arbitrum), accept crypto payments via multi-chain deposit links that auto-convert to stablecoins, and shop on Solana Pay-enabled Shopify stores — all via MoonPay's `mp` CLI. NOT for token swaps, token metadata, current wallet balances, transaction history, NFT data, or live RPC reads — for those use `alchemy-cli` (live), `alchemy-mcp`, `alchemy-api` (app code), or `agentic-gateway` (no API key). For pure cross-chain token swaps, use the `lifi` ecosystem skill.
+license: MIT
+compatibility: Requires the MoonPay `mp` CLI (install per MoonPay docs). No Alchemy API key needed — reads + payment flows go through MoonPay's hosted infrastructure. KYC and user verification handled by MoonPay's checkout / virtual-account flows. Network access required.
+metadata:
+  author: moonpay
+  version: "0.1"
+  provider: moonpay
+  partner: "true"
+---
+
+# MoonPay (Fiat On/Off-Ramps + Payments)
+
+MoonPay provides fiat-to-crypto on-ramps, crypto-to-fiat off-ramps, multi-chain crypto deposit infrastructure, and crypto checkout for Solana Pay-enabled Shopify stores. This skill covers those four payment-flow surfaces via the official `mp` CLI. For token swaps, balances, prices, transaction history, NFT data, or live RPC, use the corresponding Alchemy skill instead.
+
+| | |
+| --- | --- |
+| **Tool** | `mp <command>` (MoonPay CLI) |
+| **Auth** | KYC handled by MoonPay's hosted flows; CLI uses local wallet for signing where required |
+| **Chains (stablecoin settlement)** | Solana, Ethereum, Polygon, Base, Arbitrum, BNB |
+| **Stablecoins** | USDC, USDT, EURC (varies by chain) |
+| **Reciprocity** | MoonPay already mirrors `alchemy-api` + `alchemy-agentic-gateway` in [moonpay/skills](https://github.com/moonpay/skills) |
+
+## When to use this skill
+
+Use `moonpay` when **any** of the following are true:
+
+- The user wants to **buy crypto with fiat** (credit card / bank → BTC / SOL / ETH / USDC / etc.)
+- The user wants to **set up a fiat on/off-ramp virtual account** (USD or EUR ↔ stablecoins, with KYC + bank-account registration)
+- The user wants to **accept crypto payments** via multi-chain deposit links that auto-convert to stablecoins
+- The user wants to **pay for goods on a Solana Pay-enabled Shopify store** with crypto
+
+## When NOT to use this skill (handoff)
+
+| Need | Use instead |
+| --- | --- |
+| Token swaps (DEX / cross-chain bridge) | `lifi` (ecosystem skill) — broader bridge / DEX coverage |
+| Token prices (current, historical) | `alchemy-api` (Prices API) |
+| Token metadata, search, list by chain | `alchemy-api` (Token API) |
+| Current wallet balances | `alchemy-api` (Portfolio / Token API) |
+| Transaction history (transfers in / out) | `alchemy-api` (Transfers API) |
+| NFT metadata / floor / ownership | `alchemy-api` (NFT API) |
+| Live blockchain reads (block #, gas, `eth_call`) | `alchemy-cli` (live) or `alchemy-api` (JSON-RPC) |
+| Prediction-market integration | not in scope here (see upstream `moonpay-prediction-market` if needed) |
+| Account abstraction (bundlers, gas managers) | `alchemy-api` (Wallets / Bundler / Gas Manager) |
+| x402 / MPP (autonomous-agent payments) | `agentic-gateway` |
+| Wallet auth / hardware wallet flows | `alchemy-api` (Wallets / Account Kit) |
+
+## Scope contract
+
+**This skill covers (`scope_in`):**
+
+- **Buy crypto with fiat** (`mp buy`) — credit card / bank → crypto via MoonPay checkout URL. Supports BTC, SOL, ETH, USDC (multi-chain), USDT, MATIC, TRX.
+- **Virtual account** (`mp virtual-account *`) — full fiat on/off-ramp: KYC, agreement acceptance, wallet registration, bank-account registration (ACH / SEPA / etc.), onramp creation (fiat → stablecoin), offramp creation (stablecoin → fiat), payment / settlement flows.
+- **Multi-chain deposits** (`mp deposit *`) — permissionless deposit links that generate addresses on Solana / Ethereum / Bitcoin / Tron and auto-convert incoming crypto to a chosen stablecoin (USDC / USDT) on the destination chain.
+- **Commerce** (`mp commerce *`) — browse Solana Pay-enabled Shopify stores, search products, manage cart, checkout with crypto (USDC) via Helio integration.
+
+**This skill does NOT cover (`scope_out`):**
+
+- Token swaps (DEX or cross-chain) → handoff: `lifi` (ecosystem skill). MoonPay's upstream `moonpay-swap-tokens` overlaps with `lifi`; we route to `lifi` for broader coverage.
+- Token prices for valuation → handoff: `alchemy-api` (Prices API)
+- Token metadata, list, search → handoff: `alchemy-api` (Token API). Not the upstream `moonpay-discover-tokens`.
+- Wallet balances → handoff: `alchemy-api` (Portfolio / Token API). Not the upstream `moonpay-check-wallet`.
+- Transaction transfer history → handoff: `alchemy-api` (Transfers API)
+- NFT data → handoff: `alchemy-api` (NFT API)
+- Live RPC / block-explorer reads → handoff: `alchemy-cli` or `alchemy-api`. Not the upstream `moonpay-block-explorer`.
+- Wallet auth, hardware wallet integration → handoff: `alchemy-api` (Wallets / Account Kit). Not the upstream `moonpay-auth` / `moonpay-hardware-wallet`.
+- x402 / autonomous-agent payments → handoff: `agentic-gateway`. Not the upstream `moonpay-x402`.
+- Account abstraction → handoff: `alchemy-api`
+- Trading automation, prediction markets, price alerts, internal CLI features → out of scope here. Install `moonpay/skills` upstream alongside if you need them.
+
+## Setup
+
+Install the MoonPay `mp` CLI per [MoonPay's docs](https://docs.moonpay.com/). The CLI handles auth, wallet signing, and KYC URLs internally — there's no Alchemy API key required.
+
+For **virtual account** flows (the most involved surface), KYC needs to be completed via the URL the CLI returns. Walk the user through it; don't accept agreements on their behalf.
+
+> **Security:** when a `virtual-account agreement list` step surfaces an agreement URL, **always show the URL to the user and confirm they've reviewed it** before running `agreement accept`. Don't auto-accept on their behalf.
+
+## Endpoint reference → [references/cli.md](./references/cli.md)
+
+### `mp buy` — fiat → crypto checkout
+
+| Command | Use for |
+| --- | --- |
+| `mp buy --token <code> --amount <usd> --wallet <addr> --email <buyer>` | Returns a MoonPay checkout URL the user opens in a browser to complete a card / bank purchase. |
+
+### `mp virtual-account *` — fiat on/off-ramp
+
+| Command | Use for |
+| --- | --- |
+| `mp virtual-account create` | Create the virtual account + start KYC |
+| `mp virtual-account retrieve` | Check status (`status` + `nextStep`) |
+| `mp virtual-account kyc {continue,restart}` | KYC flow control |
+| `mp virtual-account agreement {list,accept}` | Required-agreements review and accept |
+| `mp virtual-account wallet {register,list}` | Register a wallet for the account |
+| `mp virtual-account onramp {create,retrieve,list,update,cancel}` | Fiat → stablecoin (returns deposit account / IBAN) |
+| `mp virtual-account onramp payment {create,retrieve}` | Open-banking payment flow |
+| `mp virtual-account bank-account {register,list,delete}` | Register fiat payout bank accounts |
+| `mp virtual-account offramp {create,retrieve,list,update,cancel,initiate}` | Stablecoin → fiat |
+| `mp virtual-account transaction list` | List transactions |
+
+### `mp deposit *` — permissionless deposit links
+
+| Command | Use for |
+| --- | --- |
+| `mp deposit create --name <label> --wallet <addr> --chain <chain> --token <stablecoin>` | Create a deposit link with multi-chain receive addresses; auto-converts to chosen stablecoin |
+| `mp deposit transaction list --id <deposit-id>` | List incoming deposits |
+
+Supported destination chains: `solana`, `ethereum`, `base`, `polygon`, `arbitrum`, `bnb`. Stablecoins: `USDC`, `USDT`, `USDC.e` (Polygon-bridged).
+
+### `mp commerce *` — Shopify checkout via Solana Pay
+
+| Command | Use for |
+| --- | --- |
+| `mp commerce store list` | List Solana Pay-enabled stores |
+| `mp commerce product search --store <s> --query <q>` | Search products |
+| `mp commerce product retrieve --store <s> --productId <id>` | Product details |
+| `mp commerce cart {add,retrieve,remove}` | Cart management |
+| `mp commerce checkout ...` | Sign + submit Solana Pay payment via Helio (gas paid by Helio) |
+
+## Quick examples
+
+### Buy $50 of SOL with a credit card
+
+```bash
+mp buy \
+  --token sol \
+  --amount 50 \
+  --wallet 9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM \
+  --email user@example.com
+# Returns a checkout URL — open in the user's browser
+```
+
+### Set up a USD → USDC onramp on Base
+
+```bash
+mp virtual-account create                    # starts KYC; surfaces a verification URL
+mp virtual-account agreement list            # show URLs to the user, get their OK
+mp virtual-account agreement accept --contentId <id>
+mp virtual-account wallet register --wallet main --chain base
+mp virtual-account onramp create \
+  --name "USD → USDC Base" --fiat USD --stablecoin USDC \
+  --wallet <registered-address> --chain base
+# Returns a fiat deposit account (e.g., a US bank IBAN) — wire / ACH funds in;
+# they settle as USDC on Base to the registered wallet.
+```
+
+### Accept incoming crypto payments as USDC on Base
+
+```bash
+mp deposit create \
+  --name "My Payments" \
+  --wallet 0xf1D8...5036 \
+  --chain base \
+  --token USDC
+# Returns a shareable deposit URL + per-chain addresses + QR codes.
+# Senders can pay from Solana / Ethereum / Bitcoin / Tron;
+# auto-converts to USDC on Base.
+```
+
+### Buy something from a Solana Pay Shopify store with USDC
+
+```bash
+mp commerce store list
+mp commerce product search --store ryder.id --query "ryder"
+mp commerce cart add --store ryder.id --variantId "gid://shopify/ProductVariant/..." --quantity 1
+mp commerce checkout \
+  --wallet main --store ryder.id --cartId <id> --chain solana \
+  --email buyer@example.com --firstName John --lastName Doe \
+  --address "123 Main St" --city Amsterdam --postalCode 1011 --country Netherlands
+```
+
+## Common gotchas
+
+- **`--token` uses MoonPay codes**, not contract addresses or mint addresses (e.g., `usdc_base`, not the contract). See `references/cli.md` for the supported token list.
+- **`--amount` for `mp buy` is in USD**, not in token units (`--amount 50` = $50 worth of the token, not 50 SOL).
+- **KYC is mandatory** for the virtual account flow. Surface the verification URL to the user; don't try to bypass.
+- **Agreements need explicit user consent** — list URLs, get user confirmation they've read them, then accept. Don't auto-accept.
+- **Commerce is Solana-only** for payment today, even if the store is multi-chain. The buyer pays in USDC on Solana.
+- **Deposit destination chains** are `solana / ethereum / base / polygon / arbitrum / bnb`; sender chains are `solana / ethereum / bitcoin / tron`.
+- **Helio infrastructure** powers the deposit + commerce flows under the hood. The buyer doesn't pay gas for commerce checkouts (Helio sponsors).
+
+## Routing back to Alchemy
+
+If during a session the user's need shifts to surfaces this skill doesn't cover (token swaps, balances, prices, transaction history, NFT data, live RPC), hand off:
+
+- `alchemy-cli` — live agent work in the current session via the local CLI
+- `alchemy-mcp` — live work via the hosted MCP server when CLI is not installed
+- `alchemy-api` — application code with an Alchemy API key
+- `agentic-gateway` — application code without an API key (x402 / MPP)
+
+For pure cross-chain token swaps (no fiat involved), hand off to the `lifi` ecosystem skill.
+
+---
+
+> **Maintenance:** MoonPay maintains the `mp` CLI and the underlying APIs; this skill itself is maintained jointly by Alchemy and MoonPay. File issues against `alchemyplatform/skills` with `[ecosystem/moonpay]` in the title. Reciprocity: MoonPay already mirrors `alchemy-api` and `alchemy-agentic-gateway` inside [`moonpay/skills`](https://github.com/moonpay/skills).

--- a/skills/ecosystem/moonpay/agents/openai.yaml
+++ b/skills/ecosystem/moonpay/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MoonPay"
+  short_description: "Fiat on/off-ramps, crypto deposit links, and Solana Pay commerce via MoonPay"
+  default_prompt: "Use MoonPay to buy crypto with fiat, set up a USD/EUR ↔ stablecoin virtual account (KYC + bank), accept crypto payments via auto-converting deposit links, or pay on Solana Pay Shopify stores. For token swaps, balances, or prices, use alchemy-api or lifi instead."

--- a/skills/ecosystem/moonpay/agents/openai.yaml
+++ b/skills/ecosystem/moonpay/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "MoonPay"
   short_description: "Fiat on/off-ramps, crypto deposit links, and Solana Pay commerce via MoonPay"
-  default_prompt: "Use MoonPay to buy crypto with fiat, set up a USD/EUR ↔ stablecoin virtual account (KYC + bank), accept crypto payments via auto-converting deposit links, or pay on Solana Pay Shopify stores. For token swaps, balances, or prices, use alchemy-api or lifi instead."
+  default_prompt: "Use MoonPay to buy crypto with fiat, set up a USD/EUR ↔ stablecoin virtual account (KYC + bank), accept crypto via auto-converting deposit links, pay on Solana Pay Shopify stores, swap or bridge tokens (same-chain + cross-chain), or automate DCA / limit-order / stop-loss strategies via cron or launchd. For balances, prices, transaction history, NFT data, or live RPC, use alchemy-api instead."

--- a/skills/ecosystem/moonpay/references/cli.md
+++ b/skills/ecosystem/moonpay/references/cli.md
@@ -1,0 +1,252 @@
+# MoonPay CLI Reference
+
+**Tool:** `mp <command>`
+
+Four surfaces, one CLI. These flows are non-overlapping with Alchemy first-party. For token swaps, prices, balances, transfers, or NFTs, route to `alchemy-api` or `lifi`.
+
+---
+
+## `mp buy` — fiat → crypto checkout
+
+Generate a MoonPay checkout URL for buying crypto with a credit card or bank transfer. The user completes the purchase in their browser.
+
+```bash
+mp buy \
+  --token <currency-code> \
+  --amount <usd-amount> \
+  --wallet <destination-address> \
+  --email <buyer-email>
+```
+
+### Supported currency codes
+
+`btc`, `sol`, `eth`, `trx`, `pol_polygon`, `usdc`, `usdc_sol`, `usdc_base`, `usdc_arbitrum`, `usdc_optimism`, `usdc_polygon`, `usdt_trx`, `eth_polygon`, `eth_optimism`, `eth_base`, `eth_arbitrum`
+
+### Notes
+
+- `--amount` is **in USD** (e.g., `50` = $50 worth of the token).
+- `--token` uses MoonPay currency codes — not contract addresses, not Solana mints.
+- The returned checkout URL handles KYC + payment processing client-side. The user opens it in a browser to complete.
+- For token-to-token swaps (no fiat), route to the `lifi` ecosystem skill.
+
+---
+
+## `mp virtual-account *` — fiat on/off-ramp infrastructure
+
+Comprehensive virtual account for converting between fiat (USD / EUR) and stablecoins (USDC / USDT / EURC) on Solana, Ethereum, Polygon, Base, Arbitrum.
+
+### Setup flow
+
+```bash
+# 1. Create the account + start KYC (returns a verification URL)
+mp virtual-account create
+
+# 2. Check status — `status` field shows where you are; `nextStep` says what to do next
+mp virtual-account retrieve
+
+# 3. KYC verification
+mp virtual-account kyc continue   # check status / re-fetch URL
+mp virtual-account kyc restart    # restart if something went wrong
+```
+
+### Agreements (require user consent)
+
+```bash
+# List required agreements — shows name + URL for each
+mp virtual-account agreement list
+
+# Show the URL to the user. Wait for explicit confirmation they've read it.
+# Then:
+mp virtual-account agreement accept --contentId <content-id>
+
+# View previously accepted
+mp virtual-account agreement list --status accepted
+```
+
+> **Important:** never accept agreements on the user's behalf. The CLI requires explicit consent because these are legal terms.
+
+### Wallet registration
+
+```bash
+# Creates verification message, signs locally, registers — one command
+mp virtual-account wallet register --wallet main --chain solana
+
+mp virtual-account wallet list
+```
+
+Supported chains: `solana`, `ethereum`, `polygon`, `base`, `arbitrum`.
+
+### Onramp (fiat → stablecoin)
+
+```bash
+# Create — returns deposit account (bank IBAN / account number)
+mp virtual-account onramp create \
+  --name "My Onramp" \
+  --fiat USD \
+  --stablecoin USDC \
+  --wallet <registered-wallet-address> \
+  --chain solana
+
+mp virtual-account onramp retrieve --onrampId <id>   # includes deposit account, fees, legal disclaimer
+mp virtual-account onramp list
+mp virtual-account onramp update --onrampId <id> --chain ethereum
+mp virtual-account onramp cancel --onrampId <id>
+
+# Open-banking payment
+mp virtual-account onramp payment create \
+  --onrampId <id> --amount 100 --fiat USD
+
+mp virtual-account onramp payment retrieve --onrampId <id> --paymentId <payment-id>
+```
+
+### Bank-account registration (for offramps)
+
+```bash
+# Register a USD bank account (ACH)
+mp virtual-account bank-account register \
+  --currency USD --type ACH \
+  --accountNumber <number> --routingNumber <number> \
+  --providerName "Chase" --providerCountry US \
+  --givenName John --familyName Doe \
+  --email john@example.com --phoneNumber +14155551234 \
+  --address.street "123 Main St" --address.city "New York" \
+  --address.state NY --address.country US --address.postalCode 10001
+
+mp virtual-account bank-account list
+mp virtual-account bank-account delete --bankAccountId <id>
+```
+
+### Offramp (stablecoin → fiat)
+
+```bash
+mp virtual-account offramp create \
+  --name "My Offramp" \
+  --bankAccountId <bank-account-id> \
+  --stablecoin USDC \
+  --chain solana
+
+mp virtual-account offramp list
+mp virtual-account offramp retrieve --offrampId <id>
+mp virtual-account offramp update --offrampId <id> --fiat EUR
+mp virtual-account offramp cancel --offrampId <id>
+
+# Send stablecoin to an approved offramp (signs + broadcasts locally)
+mp virtual-account offramp initiate \
+  --wallet main --offrampId <id> --amount 100
+```
+
+### Other
+
+```bash
+mp virtual-account transaction list
+```
+
+---
+
+## `mp deposit *` — permissionless multi-chain deposit links
+
+Generate a deposit link that exposes addresses on Solana, Ethereum, Bitcoin, and Tron. Anyone can send any token; Helio auto-converts to the chosen stablecoin and settles to the destination wallet on the chosen chain.
+
+No login required.
+
+```bash
+mp deposit create \
+  --name <label> \
+  --wallet <destination-address> \
+  --chain <destination-chain> \
+  --token <stablecoin>
+```
+
+### Supported destination chains
+
+`solana`, `ethereum`, `base`, `polygon`, `arbitrum`, `bnb`
+
+### Supported tokens
+
+- `USDC` — all chains
+- `USDT` — all chains
+- `USDC.e` — bridged USDC, Polygon only
+
+### How it works
+
+1. `mp deposit create` returns a deposit URL + per-chain addresses + QR codes.
+2. Sender pays from Solana / Ethereum / Bitcoin / Tron — any token.
+3. Helio auto-converts to the chosen stablecoin and delivers to the destination wallet.
+4. `mp deposit transaction list --id <deposit-id>` shows incoming payments.
+
+### Notes
+
+- No login or account required — deposits are permissionless.
+- Each `deposit create` generates unique addresses — don't reuse addresses from different deposits.
+- The deposit URL opens a web page where senders pick how to pay.
+
+---
+
+## `mp commerce *` — Solana Pay Shopify checkout
+
+Browse Solana Pay-enabled Shopify stores, manage a cart, and pay with crypto (USDC) via Helio. Entire flow runs from the CLI; no browser needed.
+
+```bash
+# 1. Browse
+mp commerce store list
+
+# 2. Search for products
+mp commerce product search --store <store> --query <search-term>
+mp commerce product retrieve --store <store> --productId <product-id>
+
+# 3. Cart management
+mp commerce cart add \
+  --store <store> --variantId <variant-id> --quantity <n> \
+  --cartId <cart-id>           # omit to create a new cart
+
+mp commerce cart retrieve --store <store> --cartId <cart-id>
+mp commerce cart remove   --store <store> --cartId <cart-id> --lineId <line-id>
+
+# 4. Checkout (signs + submits Solana Pay tx)
+mp commerce checkout \
+  --wallet <wallet-name> \
+  --store <store> --cartId <cart-id> --chain solana \
+  --email <buyer-email> \
+  --firstName <first> --lastName <last> \
+  --address <street-address> --city <city> --postalCode <zip> --country <country-name>
+```
+
+### How it works
+
+1. Stores expose a Shopify MCP endpoint for browsing + cart.
+2. `cart add` creates or updates a cart (no auth needed; cart ID is the handle).
+3. `checkout` calls the API to start a Helio payment, signs the tx locally, submits.
+4. Helio pays gas — the buyer only pays the item price in USDC.
+5. Returns a tx signature + order confirmation URL.
+
+### Notes
+
+- `--country` takes full country names (e.g., "United States", "Netherlands").
+- Checkout takes 30-90 seconds — the API automates the Shopify checkout flow.
+- Currently Solana-only for payment, even on multi-chain stores.
+
+---
+
+## Out of scope here (use upstream `moonpay/skills` directly if you need them)
+
+The upstream `moonpay/skills` repo includes ~30+ skills. The non-overlapping subset we mirror is the four CLI surfaces above. The rest are out of scope for this curated skill because they overlap with Alchemy first-party or other ecosystem skills:
+
+| Upstream skill | Why scope_out | Use |
+| --- | --- | --- |
+| `moonpay-swap-tokens` | Overlaps with `lifi` (broader DEX + bridge coverage) | `lifi` ecosystem skill |
+| `moonpay-trading-automation` | Overlaps with multiple swap / trading surfaces | `lifi` + `alchemy-api` |
+| `moonpay-auth` | Overlaps with Alchemy Wallets / Account Kit | `alchemy-api` |
+| `moonpay-x402` | Overlaps with our `agentic-gateway` (already does x402) | `agentic-gateway` |
+| `moonpay-discover-tokens` | Partial overlap with Token API | `alchemy-api` (Token API) |
+| `moonpay-block-explorer` | Overlaps with general blockchain reads | `alchemy-api` (JSON-RPC) |
+| `moonpay-check-wallet` | Overlaps with Portfolio API | `alchemy-api` (Portfolio API) |
+| `moonpay-price-alerts` | Partial overlap with Prices API | `alchemy-api` (Prices API) |
+| `moonpay-hardware-wallet` | Wallet territory | `alchemy-api` (Wallets) |
+| `moonpay-prediction-market`, `moonpay-fund-polymarket` | Niche, prediction-market specific | upstream directly if needed |
+| `moonpay-mcp`, `moonpay-export-data`, `moonpay-feedback`, `moonpay-missions`, `moonpay-scout`, `moonpay-upgrade`, `moonpay-wallet-statusline*` | Internal product features or unrelated tooling | upstream directly if needed |
+
+To install the full MoonPay surface alongside this curated subset:
+
+```bash
+npx skills add moonpay/skills
+```

--- a/skills/ecosystem/moonpay/references/cli.md
+++ b/skills/ecosystem/moonpay/references/cli.md
@@ -227,14 +227,255 @@ mp commerce checkout \
 
 ---
 
+## `mp token *` — same-chain swap + cross-chain bridge
+
+Same-chain swaps and cross-chain bridges via [swaps.xyz](https://swaps.xyz). Builds the unsigned tx, handles ERC-20 approvals, signs locally, broadcasts.
+
+### Same-chain swap
+
+```bash
+mp token swap \
+  --wallet <wallet-name> \
+  --chain <chain> \
+  --from-token <token-address> \
+  --from-amount <amount> \
+  --to-token <token-address>
+```
+
+Use `--to-amount` instead of `--from-amount` for exact-output swaps.
+
+### Cross-chain bridge
+
+```bash
+mp token bridge \
+  --from-wallet <wallet-name> \
+  --from-chain <chain> \
+  --from-token <token-address> \
+  --from-amount <amount> \
+  --to-chain <chain> \
+  --to-token <token-address> \
+  --to-wallet <wallet-name>     # optional; defaults to from-wallet
+```
+
+Same `--to-amount` exact-out support.
+
+### Examples
+
+```bash
+# SOL → USDC on Solana
+mp token swap \
+  --wallet main --chain solana \
+  --from-token So11111111111111111111111111111111111111111 \
+  --from-amount 0.1 \
+  --to-token EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+
+# ETH on Ethereum → USDC.e on Polygon (cross-chain)
+mp token bridge \
+  --from-wallet funded --from-chain ethereum \
+  --from-token 0x0000000000000000000000000000000000000000 \
+  --from-amount 0.003 \
+  --to-chain polygon \
+  --to-token 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174
+
+# ERC-20 swap (auto-approves first time)
+mp token swap \
+  --wallet funded --chain polygon \
+  --from-token 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174 \
+  --from-amount 5 \
+  --to-token 0x0000000000000000000000000000000000000000
+```
+
+### Supported chains
+
+`solana`, `ethereum`, `base`, `polygon`, `arbitrum`, `optimism`, `bnb`, `avalanche`, `bitcoin` (bridges only).
+
+### Helpers
+
+```bash
+# Resolve names → addresses
+mp token search --query "USDC" --chain solana
+
+# Check balances pre-swap
+mp token balance list --wallet <address> --chain <chain>
+```
+
+### Native-token addresses
+
+- EVM chains: `0x0000000000000000000000000000000000000000`
+- Solana: `So11111111111111111111111111111111111111111`
+
+`token swap` calls `token bridge` under the hood with `from-chain == to-chain`.
+
+---
+
+## Trading automation — `mp` + cron / launchd
+
+Compose the `mp` CLI with OS scheduling to run unattended trading strategies: dollar-cost averaging, limit orders, and stop losses. The skill generates shell scripts at `~/.config/moonpay/scripts/` and schedules them — no separate tooling needed.
+
+### Prerequisites
+
+```bash
+mp user retrieve                                      # authenticated
+mp token balance list --wallet <name> --chain <chain> # funded
+which mp                                              # absolute path for cron / launchd
+which jq                                              # JSON parsing
+```
+
+### Base script pattern
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+MP="$(which mp)"  # absolute path; cron / launchd have minimal PATH
+LOG="$HOME/.config/moonpay/logs/trading.log"
+mkdir -p "$(dirname "$LOG")"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >> "$LOG"; }
+
+# --- Config (agent fills these in per strategy) ---
+WALLET="main"
+CHAIN="solana"
+FROM_TOKEN="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"  # USDC
+TO_TOKEN="So11111111111111111111111111111111111111111"     # SOL
+AMOUNT=5
+
+# --- Execute ---
+log "SWAP: $AMOUNT $FROM_TOKEN -> $TO_TOKEN on $CHAIN"
+RESULT=$("$MP" --json token swap \
+  --wallet "$WALLET" --chain "$CHAIN" \
+  --from-token "$FROM_TOKEN" --from-amount "$AMOUNT" \
+  --to-token "$TO_TOKEN" 2>&1) || {
+  log "FAILED: $RESULT"
+  exit 1
+}
+log "OK: $RESULT"
+```
+
+`mp --json` outputs single-line JSON for `jq` parsing.
+
+### DCA (dollar-cost averaging)
+
+> "Buy $5 of SOL every day at 9am UTC"
+
+Use the base script as-is. Schedule:
+
+```bash
+# Linux (crontab)
+(crontab -l 2>/dev/null; \
+ echo '0 9 * * * ~/.config/moonpay/scripts/dca-sol.sh # moonpay:dca-sol') | crontab -
+
+# Common cron intervals:
+#   0 * * * *      hourly
+#   0 */4 * * *    every 4 hours
+#   0 9 * * *      daily at 9am
+#   0 9 * * 1      weekly Monday 9am
+```
+
+```xml
+<!-- macOS launchd: ~/Library/LaunchAgents/com.moonpay.dca-sol.plist -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.moonpay.dca-sol</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/USERNAME/.config/moonpay/scripts/dca-sol.sh</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+  <key>StandardErrorPath</key>
+  <string>/Users/USERNAME/.config/moonpay/logs/dca-sol.err</string>
+</dict>
+</plist>
+```
+
+Load: `launchctl load ~/Library/LaunchAgents/com.moonpay.dca-sol.plist`. Tilde does **not** expand in plists — use `echo $HOME` for the absolute path.
+
+### Limit order
+
+> "Buy $50 of SOL when price drops below $80"
+
+Pattern: poll price every 5 min; execute swap when condition met; self-disable after fill.
+
+```bash
+# Inside the base script, replace the Execute block with:
+PRICE=$("$MP" --json token search --query "$TOKEN" --chain "$CHAIN" \
+  | jq -r '.items[0].marketData.price')
+
+if [ -z "$PRICE" ] || [ "$PRICE" = "null" ]; then
+  log "LIMIT: price fetch failed, skipping"
+  exit 0
+fi
+
+if (( $(echo "$PRICE < $TARGET_PRICE" | bc -l) )); then
+  log "LIMIT: price $PRICE < $TARGET_PRICE — executing buy"
+  RESULT=$("$MP" --json token swap \
+    --wallet "$WALLET" --chain "$CHAIN" \
+    --from-token "$BUY_WITH" --from-amount "$BUY_AMOUNT" \
+    --to-token "$TOKEN" 2>&1) || { log "FAILED: $RESULT"; exit 1; }
+  log "OK: bought at $PRICE"
+
+  # Self-disable after fill
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    launchctl unload "$HOME/Library/LaunchAgents/com.moonpay.${SCRIPT_NAME}.plist" 2>/dev/null || true
+  else
+    crontab -l | grep -v "$SCRIPT_NAME" | crontab -
+  fi
+else
+  log "LIMIT: price $PRICE >= $TARGET_PRICE — waiting"
+fi
+```
+
+Schedule every 5 min:
+- cron: `*/5 * * * * ~/.config/moonpay/scripts/limit-buy-sol.sh # moonpay:limit-buy-sol`
+- launchd: `<key>StartInterval</key><integer>300</integer>` instead of `StartCalendarInterval`
+
+### Stop loss
+
+Same structure as limit order, but:
+- Trigger when `price < trigger_price`
+- Sell entire balance: query via `mp token balance list`, then `mp token swap` from sell-token to a stablecoin
+- Self-disable after fill
+
+### Managing automations
+
+```bash
+# List active
+launchctl list | grep moonpay      # macOS
+crontab -l | grep moonpay          # Linux
+
+# Remove
+launchctl unload ~/Library/LaunchAgents/com.moonpay.dca-sol.plist
+rm ~/Library/LaunchAgents/com.moonpay.dca-sol.plist
+crontab -l | grep -v "moonpay:dca-sol" | crontab -
+
+# Pause / resume (macOS)
+launchctl unload ~/Library/LaunchAgents/com.moonpay.dca-sol.plist
+launchctl load ~/Library/LaunchAgents/com.moonpay.dca-sol.plist
+
+# Logs
+tail -50 ~/.config/moonpay/logs/trading.log
+```
+
+### Tips
+
+- Start with a small DCA amount before scaling up.
+- Keychain access requires an active user session — don't schedule on a machine that auto-locks aggressively.
+- macOS launchd fires even after sleep; cron does not.
+- Always tag cron entries with `# moonpay:{name}` so they're easy to find / remove.
+- Use `bc -l` for decimal price comparison; bash can't compare floats natively. If `bc` isn't available: `awk "BEGIN {exit !($PRICE < $TARGET)}"`.
+
+---
+
 ## Out of scope here (use upstream `moonpay/skills` directly if you need them)
 
-The upstream `moonpay/skills` repo includes ~30+ skills. The non-overlapping subset we mirror is the four CLI surfaces above. The rest are out of scope for this curated skill because they overlap with Alchemy first-party or other ecosystem skills:
+The upstream `moonpay/skills` repo includes ~30+ skills. We mirror six surfaces above (buy, virtual-account, deposit, commerce, swap/bridge, trading-automation). The rest are out of scope for this curated skill because they overlap with Alchemy first-party or are niche / internal:
 
 | Upstream skill | Why scope_out | Use |
 | --- | --- | --- |
-| `moonpay-swap-tokens` | Overlaps with `lifi` (broader DEX + bridge coverage) | `lifi` ecosystem skill |
-| `moonpay-trading-automation` | Overlaps with multiple swap / trading surfaces | `lifi` + `alchemy-api` |
 | `moonpay-auth` | Overlaps with Alchemy Wallets / Account Kit | `alchemy-api` |
 | `moonpay-x402` | Overlaps with our `agentic-gateway` (already does x402) | `agentic-gateway` |
 | `moonpay-discover-tokens` | Partial overlap with Token API | `alchemy-api` (Token API) |


### PR DESCRIPTION
<!-- PR title: feat(ecosystem): add MoonPay skill (fiat ramps + payments + swap/bridge + automation) -->
<!-- Local branch: ecosystem-moonpay -->
<!-- Original PR: not yet opened (held pending partner conversation) -->

## Summary

- Adds **MoonPay** as an ecosystem partner skill (`skills/ecosystem/moonpay/`), curated subset of [`moonpay/skills`](https://github.com/moonpay/skills)
- Drives the official `mp` CLI for: fiat → crypto checkout (`mp buy`), full fiat on/off-ramp virtual account (`mp virtual-account *`), permissionless multi-chain deposit links (`mp deposit *`), Solana Pay Shopify checkout (`mp commerce *`), same-chain swap + cross-chain bridge (`mp token swap` / `mp token bridge`), and trading automation (DCA / limit / stop loss via cron or launchd)
- Adds the path to `.claude-plugin/plugin.json` so the Vercel `npx skills` CLI discovers it

## Scope

**In:** `mp buy` (BTC, SOL, ETH, USDC multi-chain, USDT, etc.), `mp virtual-account *` (KYC + bank registration + USD/EUR ↔ stablecoins on Solana, Ethereum, Polygon, Base, Arbitrum), `mp deposit *` (multi-chain deposit links auto-converting to chosen stablecoin), `mp commerce *` (Solana Pay Shopify checkout via Helio), `mp token swap` / `mp token bridge` (same-chain + cross-chain swaps via swaps.xyz across Solana, EVM L1s/L2s, BTC for bridges), and trading automation (shell-script + cron / launchd patterns composing the above for DCA / limit-order / stop-loss).

**Out (routes back to first-party Alchemy):** token prices → Prices API · token metadata → Token API · balances → Portfolio API · transaction history → Transfers API · NFTs → NFT API · live RPC / block-explorer reads → JSON-RPC · wallet auth, hardware wallet, AA → Wallets / Account Kit · x402 → `agentic-gateway` (decline upstream `moonpay-x402`) · prediction markets, internal CLI features (mcp, scout, missions, statusline, feedback, upgrade, export-data) → out of scope; install upstream `moonpay/skills` directly if needed.

## Test plan

- [x] `npx skills add . --list` finds 6 skills: 4 first-party + `allium` + `moonpay` (allium and moonpay both under "Alchemy" group from manifest)
- [x] MoonPay `scope_in` audited against `alchemy-api` (Token, Portfolio, Prices, Transfers, NFT, Simulation, JSON-RPC) — zero overlap; the six mirrored surfaces (fiat onramp/offramp, deposit links, commerce, swap/bridge, trading automation) are gaps Alchemy doesn't cover first-party

Made with [Cursor](https://cursor.com)