### PR TITLE
[docs-agent] Weekly skills update 2026-05-13

### DIFF
--- a/skills/alchemy-api/references/operational-rate-limits-and-compute-units.md
+++ b/skills/alchemy-api/references/operational-rate-limits-and-compute-units.md
@@ -9,7 +9,7 @@ tags:
 related:
   - operational-pricing-and-plans.md
   - data-apis
-updated: 2026-02-05
+updated: 2026-05-13
 ---
 # Rate Limits and Compute Units
 
@@ -24,6 +24,19 @@ Alchemy meters usage using compute units (CU) and enforces per-key rate limits. 
 ## Practical Patterns
 - Use pagination and resume tokens (`pageKey`) for large datasets.
 - Cache token metadata and NFT metadata aggressively.
+
+## Webhooks and WebSocket Subscriptions Pricing
+Most webhooks and WebSocket subscriptions are priced by **bandwidth** at `0.04 CU / byte`. A typical 1000-byte event consumes 40 CU.
+
+**Exceptions — per-event pricing on Base Flashblocks subscriptions:**
+
+| Subscription | Pricing |
+|---|---|
+| `newFlashblockTransactions` | 40 CU / event |
+| `newFlashblocks` | 60 CU / event |
+| All other subscriptions | 0.04 CU / byte |
+
+When estimating cost for high-volume Flashblocks consumers, treat each event as a fixed CU charge regardless of payload size.
 
 ## Related Files
 - `operational-pricing-and-plans.md`

--- a/skills/alchemy-api/references/operational-supported-networks.md
+++ b/skills/alchemy-api/references/operational-supported-networks.md
@@ -9,17 +9,20 @@ tags:
 related:
   - node-json-rpc.md
   - solana-rpc.md
-updated: 2026-04-22
+updated: 2026-05-13
 ---
 # Supported Networks
 
 ## Summary
-Alchemy supports multiple EVM and Solana networks. Always verify network availability in the dashboard for each product.
+Alchemy supports multiple EVM, Solana, and UTXO networks. Always verify network availability in the dashboard for each product.
 
 ## Guidance
-- Use chain-specific base URLs (e.g., `eth-mainnet`, `polygon-mainnet`).
+- Use chain-specific base URLs (e.g., `eth-mainnet`, `polygon-mainnet`, `bitcoincash-mainnet`).
 - Use testnets for QA.
 - Not all products are available on every chain.
+
+## Recently Added
+- **Bitcoin Cash, Litecoin, Dogecoin** — added as UTXO JSON-RPC chains alongside Bitcoin. Network slugs: `bitcoincash-mainnet`, `bitcoincash-testnet`, `litecoin-mainnet`, `litecoin-testnet`, `dogecoin-mainnet`. All four share the same Bitcoin-Core-style JSON-RPC method set (`getblock`, `sendrawtransaction`, etc.) and a common UTXO REST API (Trezor Blockbook-derived). The UTXO REST surface is mounted under `https://{network}.g.alchemy.com/v2/{apiKey}/api/v2/...` across all seven UTXO networks (the four new ones plus `bitcoin-mainnet` and `bitcoin-testnet4`).
 
 ## Recently Deprecated / Removed
 - **Arbitrum Nova** — deprecated. Nova endpoints (`arbnova-mainnet`, `ARBNOVA_MAINNET`) are no longer supported across Node, Wallets (Bundler, Gas Manager), and related products. See the [Arbitrum Nova deprecation notice](https://www.alchemy.com/docs/reference/arbitrum-nova/arbitrum-nova-deprecation-notice) for migration guidance.
@@ -113,6 +116,9 @@ berachain-mainnet
 bitcoin-mainnet
 bitcoin-signet
 bitcoin-testnet
+bitcoin-testnet4
+bitcoincash-mainnet
+bitcoincash-testnet
 blast-mainnet
 blast-sepolia
 bnb-mainnet
@@ -135,6 +141,7 @@ crossfi-mainnet
 crossfi-testnet
 degen-mainnet
 degen-sepolia
+dogecoin-mainnet
 earnm-mainnet
 earnm-sepolia
 edge-mainnet
@@ -168,6 +175,8 @@ lens-mainnet
 lens-sepolia
 linea-mainnet
 linea-sepolia
+litecoin-mainnet
+litecoin-testnet
 mantle-mainnet
 mantle-sepolia
 megaeth-mainnet

--- a/skills/alchemy-api/references/solana-das-api.md
+++ b/skills/alchemy-api/references/solana-das-api.md
@@ -7,7 +7,7 @@ tags:
   - solana
 related:
   - solana-rpc.md
-updated: 2026-02-23
+updated: 2026-05-13
 ---
 # Solana DAS (Digital Asset Standard) API
 
@@ -231,19 +231,27 @@ Same structure as `getAssetsByOwner` (`total`, `limit`, `page`, `items`).
 
 ## `searchAssets`
 
-Search assets by various criteria.
+Search assets by various criteria. `ownerAddress` is required by the Alchemy DAS proxy on every call (even when other filters are also supplied).
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `ownerAddress` | string | No | Filter by owner |
-| `grouping` | array | No | Filter by group (e.g., `[{ "group_key": "collection", "group_value": "..." }]`) |
-| `burnt` | boolean | No | Filter by burn status |
-| `frozen` | boolean | No | Filter by frozen status |
-| `interface` | string | No | Filter by interface type |
-| `page` | integer | No | Page number |
-| `limit` | integer | No | Results per page |
+| `ownerAddress` | string | **Yes** | Owner wallet pubkey. Required on every call. |
+| `tokenType` | string | No | `"fungible"`, `"nonFungible"`, `"regularNFT"`, `"compressedNFT"`, or `"all"`. Prefer over `interface` — they are mutually exclusive server-side. Note: values are case-sensitive (`NFT` uppercase). |
+| `interface` | string | No | Legacy filter. Mutually exclusive with `tokenType`. |
+| `sortBy` | object | No | `{ "sortBy": "created"\|"updated"\|"recent_action"\|"id"\|"none", "sortDirection": "asc"\|"desc" }`. Cursor-based pagination (`before`/`after`) requires `sortBy: "id"`. Note: enum values are snake_case. |
+| `limit` | integer | No | Page size, max 1000, default 100. |
+| `page` | integer | No | 1-indexed page number. Switches the server to page-based pagination. |
+| `before`, `after`, `cursor` | string | No | Cursor-based pagination tokens. Mutually exclusive with `page` — pick one strategy. |
+| `negate` | boolean | No | Invert the filter set. Default `false`. |
+| `conditionType` | string | No | `"all"` (default — every filter must match) or `"any"`. |
+| `creatorAddress`, `creatorVerified`, `authorityAddress`, `delegate`, `supplyMint`, `royaltyTarget` | string / boolean | No | Pubkey or boolean filters. Note: server field is `delegate` (not `delegateAddress`). |
+| `frozen`, `burnt`, `compressed`, `compressible` | boolean | No | Status filters. |
+| `royaltyTargetType` | string | No | `"creators"`, `"fanout"`, or `"single"`. |
+| `royaltyAmount` | integer | No | Basis points (0–10000). |
+| `options` / `displayOptions` | object | No | `showUnverifiedCollections`, `showCollectionMetadata`, `showZeroBalance`, `showInscription`, `showFungible`. Server treats `options` and `displayOptions` as aliases — pass only one, not both. |
+| `grouping` | array | No | 2-tuple `["<groupKey>", "<groupValue>"]`, e.g. `["collection", "<collectionAddress>"]`. Not exposed in the Try It form — pass it directly when calling the API yourself. |
 
 ### Request
 
@@ -255,17 +263,63 @@ curl -s -X POST https://solana-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY \
     "id": 1,
     "method": "searchAssets",
     "params": {
-      "ownerAddress": "83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",
-      "grouping": [{ "group_key": "collection", "group_value": "J1S9H3QjnRtBbbuD4HjPV6RpRhwuk4zKbxsnCHuTgh9w" }],
+      "ownerAddress": "86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY",
+      "tokenType": "all",
+      "sortBy": { "sortBy": "created", "sortDirection": "asc" },
       "page": 1,
-      "limit": 10
+      "limit": 50
     }
   }'
 ```
 
 ### Response
 
-Same structure as `getAssetsByOwner`.
+Same envelope as `getAssetsByOwner` (`total`, `limit`, `page`, `items`).
+
+### Gotchas
+
+- Phantom fields that previously appeared in the spec but are NOT accepted by the server: `delegateAddress` (use `delegate`), `mutable`, `tree`, `programId`, `commitment`, `minContextSlot`, `dataSlice`, `encoding`.
+- Pagination is mutually exclusive — `page` vs `before`/`after`/`cursor`. Sending more than one returns `Pagination Error. Only one pagination parameter supported per query.`
+- `before`/`after` (cursor pagination) requires `sortBy.sortBy: "id"`; any other sort with cursor pagination yields `Pagination Sorting Error`.
+- `ownerType` + `tokenType` are mutually exclusive. `interface` + `tokenType` are mutually exclusive. Prefer `tokenType` and drop the other.
+
+---
+
+## `getTokenAccounts`
+
+Returns token accounts filtered by owner, mint, or both. At least one of `ownerAddress` or `mintAddress` is required.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `ownerAddress` | string | Yes (if `mintAddress` not set) | — | Wallet pubkey. Common case: list a wallet's token holdings. |
+| `mintAddress` | string | Yes (if `ownerAddress` not set) | — | Mint pubkey. Pass alongside `ownerAddress` to narrow a wallet's holdings to a specific mint, or alone to list every token account for a mint. |
+| `page` | integer | No | `1` | 1-indexed page number. Use either `page` or cursor pagination, not both. |
+| `limit` | integer | No | `100` | Max accounts per page, up to 1000. |
+| `cursor`, `before`, `after` | string | No | — | Cursor-based pagination tokens. Mutually exclusive with `page`. |
+| `options` / `displayOptions` | object | No | — | `showZeroBalance` to include accounts with zero token balance. `options` and `displayOptions` are aliases — pass only one. |
+
+### Request
+
+```bash
+curl -s -X POST https://solana-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "getTokenAccounts",
+    "params": {
+      "ownerAddress": "86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY",
+      "limit": 100
+    }
+  }'
+```
+
+### Gotchas
+
+- Phantom fields that look like standard Solana RPC but are NOT accepted: `programId`, `commitment`, `minContextSlot`, `dataSlice`, `encoding`. These are part of `getTokenAccountsByOwner` (standard Solana RPC), not DAS `getTokenAccounts`.
+- If neither `ownerAddress` nor `mintAddress` is provided, the server returns `Either 'ownerAddress' or 'mintAddress' must be provided`.
 
 ---
 

--- a/skills/alchemy-api/references/solana-rpc.md
+++ b/skills/alchemy-api/references/solana-rpc.md
@@ -9,7 +9,7 @@ tags:
 related:
   - solana-das-api.md
   - solana-wallets.md
-updated: 2026-02-23
+updated: 2026-05-13
 ---
 # Solana JSON-RPC
 
@@ -230,6 +230,36 @@ curl -s -X POST https://solana-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY \
 | `meta.postTokenBalances` | array | Post-execution token balances |
 | `meta.logMessages` | string[] | Program log messages |
 | `meta.err` | object | Error (null on success) |
+
+---
+
+## `getTransactionsForAddress`
+
+Returns confirmed transactions for an address with richer filtering than `getSignaturesForAddress`. Use this when you need the full transaction objects (not just signatures) and want to filter by status, slot range, block time, or token accounts in one call.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `address` | string | Yes | — | Base58 public key |
+| `config.transactionDetails` | string | No | `"signatures"` | `"signatures"` returns just signatures; `"full"` returns full transactions |
+| `config.sortOrder` | string | No | `"desc"` | `"asc"` (oldest first) or `"desc"` (newest first) |
+| `config.limit` | integer | No | `1000` | Max results (max 1000) |
+| `config.paginationToken` | string | No | — | Cursor from a prior response |
+| `config.before` | string | No | — | Return results before this signature |
+| `config.until` | string | No | — | Return results until this signature |
+| `config.encoding` | string | No | `"json"` | `"json"`, `"jsonParsed"`, `"base64"` (only when `transactionDetails: "full"`) |
+| `config.maxSupportedTransactionVersion` | integer | No | — | Set to `0` for versioned transactions |
+| `config.filters.status` | string | No | — | `"any"`, `"succeeded"`, or `"failed"` |
+| `config.filters.slot` | object | No | — | `{ gte, lte }` range filter on slot number |
+| `config.filters.blockTime` | object | No | — | `{ gte, lte }` range filter on Unix timestamp |
+| `config.filters.tokenAccounts` | string[] | No | — | Only return transactions touching these token accounts |
+
+### Response
+
+Returns `{ data, paginationToken }`. `data` is an array of signature objects (default) or full transaction objects (when `transactionDetails: "full"`). `paginationToken` is `null` when no more pages are available.
+
+Prefer `getTransactionsForAddress` over `getSignaturesForAddress` + per-signature `getTransaction` calls when you need full transactions for an address — it's a single call instead of N+1.
 
 ---
 

--- a/skills/alchemy-api/references/wallets-wallet-apis.md
+++ b/skills/alchemy-api/references/wallets-wallet-apis.md
@@ -8,7 +8,7 @@ tags:
 related:
   - wallets-account-kit.md
   - operational-auth-and-keys.md
-updated: 2026-04-22
+updated: 2026-05-13
 ---
 # Wallet APIs
 
@@ -30,6 +30,14 @@ Undelegation removes smart contract delegation from an EIP-7702 account by deleg
 ## Integration Notes
 - Prefer client-side signing for user security.
 - Use server-side APIs only with strong access controls.
+
+## Tracking Sends: Call ID, Not Transaction Hash
+Wallet API sends (`sendCalls`, `sendPreparedCalls`) return a **call ID**, not a transaction hash. Use the call ID as the canonical reference for any single send, both for status polling and for surfacing to end users.
+
+- Poll status via `waitForCallsStatus({ id })` or `getCallsStatus({ id })`. Both return a `CallStatus` object with `id`, `status` (`"pending"`, `"success"`, `"failure"`), `chainId`, `atomic`, and `receipts[]`.
+- A single call ID can correspond to multiple receipts (one per inner transaction on non-atomic chains) or to zero receipts (if the call has not yet been included). Do NOT assume `receipts[0].transactionHash` is always populated.
+- Block explorers index by transaction hash, so once a call confirms you can dig into `status.receipts[].transactionHash` for an explorer link, but the call ID is what the Wallet API itself accepts as a lookup key.
+- This is the pattern surfaced in the v5 SDK quickstarts and recipes — log the call ID, log the status, and only follow up with `transactionHash` if you specifically need an explorer URL.
 
 ## Common Errors & Troubleshooting
 When users report Wallet API failures, check for these common error patterns:

--- a/skills/alchemy-cli/SKILL.md
+++ b/skills/alchemy-cli/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: alchemy-cli
-description: Use the Alchemy CLI (`@alchemy/cli`) for live blockchain data, transaction lookups, NFT/token/portfolio queries, simulation, tracing/debugging, account abstraction (bundler + gas manager), webhook management, Solana RPC/DAS, and Alchemy app administration. Preferred runtime path for live agent work (querying, admin, local automation) when the CLI is installed locally — or when both CLI and MCP are available. If neither is installed, install the CLI with `npm i -g @alchemy/cli`. Use for live agent work in this session, not for building application code that ships to production. For application code, use the `alchemy-api` skill (with API key) or `agentic-gateway` skill (without).
+description: Use the Alchemy CLI (`@alchemy/cli`) for live blockchain data, transaction lookups, NFT/token/portfolio queries, simulation, tracing/debugging, contract reads/writes, wallet-signed sends, swaps and cross-chain bridges, Solana RPC/DAS plus wallet sends, webhook management, and Alchemy app administration. Preferred runtime path for live agent work (querying, admin, local automation) when the CLI is installed locally — or when both CLI and MCP are available. If neither is installed, install the CLI with `npm i -g @alchemy/cli`. Use for live agent work in this session, not for building application code that ships to production. For application code, use the `alchemy-api` skill (with API key) or `agentic-gateway` skill (without).
 license: MIT
-compatibility: Requires `@alchemy/cli` (`npm i -g @alchemy/cli`) and shell access. Verified against `@alchemy/cli` 0.6.x. Works across Claude Code, Cursor, Codex, and any agent with shell access.
+compatibility: Requires `@alchemy/cli` (`npm i -g @alchemy/cli`) and shell access. Works across Claude Code, Cursor, Codex, and any agent with shell access.
 metadata:
   author: alchemyplatform
-  version: "2.0"
+  version: "2.1"
 ---
 # Alchemy CLI
 
-Use the [Alchemy CLI](https://www.npmjs.com/package/@alchemy/cli) (`@alchemy/cli`) for live blockchain queries, admin work, and local automation from the terminal. The CLI maps every Alchemy product (Node JSON-RPC, Token, NFT, Transfers, Prices, Portfolio, Simulation, Solana, Webhooks, Apps) to `alchemy <command>` invocations with structured JSON output.
+Use the [Alchemy CLI](https://www.npmjs.com/package/@alchemy/cli) (`@alchemy/cli`) for live blockchain queries, admin work, transaction signing, and local automation from the terminal. The CLI groups commands by chain (`evm`, `solana`, `xchain`) and by product area (`wallet`, `app`, `webhook`, `auth`, `config`), each with structured JSON output.
 
 ## When to use this skill
 
@@ -60,15 +60,15 @@ alchemy --json --no-interactive agent-prompt
 Before the first command, run **both** of these checks:
 
 ```bash
-alchemy --json --no-interactive setup status
-alchemy --json --no-interactive gas
+alchemy --json --no-interactive doctor
+alchemy --json --no-interactive evm gas
 ```
 
-`setup status` returns `{"complete": true, "satisfiedBy": "<source>"}` if any auth is configured. **Do not rely on `complete: true` alone** — there is a known false positive where `setup status` reports `complete: true` with `satisfiedBy: "auth_token"`, but RPC commands still fail with `AUTH_REQUIRED` because no API key has been derived from the auth token.
+`doctor` (alias: `alchemy config status`) reports what's configured plus a `nextCommands` list of remediation steps. **Do not rely on its top-level OK alone** — there is a known false positive where it reports the session is set up but RPC commands still fail with `AUTH_REQUIRED` because no API key has been derived from the auth token.
 
-`gas` is a lightweight RPC smoke test that catches this. If it returns `{"gasPrice": "0x...", ...}`, RPC is wired up correctly. If it returns `{"error": {"code": "AUTH_REQUIRED", ...}}`, run `alchemy auth login` (which fetches and saves the API key) or `alchemy config set api-key <key>`, then re-run `gas` to confirm.
+`evm gas` is a lightweight RPC smoke test that catches this. If it returns `{"gasPrice": "0x...", ...}`, RPC is wired up correctly. If it returns `{"error": {"code": "AUTH_REQUIRED", ...}}`, run `alchemy auth login` (which fetches and saves the API key) or `alchemy config set api-key <key>`, then re-run `evm gas` to confirm.
 
-If `setup status` reports `complete: false`, follow the `nextCommands` in the response first, then run `gas` to verify.
+If `doctor` reports missing config, follow its `nextCommands` first, then run `evm gas` to verify.
 
 ## Auth setup
 
@@ -78,7 +78,7 @@ The fastest way to authenticate is via browser login:
 alchemy auth login
 ```
 
-This opens a browser to authenticate with your Alchemy account and automatically configures the CLI with your credentials.
+This opens a browser, completes the OAuth flow, and configures both the API key (for RPC/Data) and the Admin API access internally. There is no separate access key step anymore — admin commands (`alchemy app ...`) work straight after `alchemy auth login`.
 
 To check auth status: `alchemy auth status`
 To log out: `alchemy auth logout`
@@ -87,121 +87,162 @@ To log out: `alchemy auth logout`
 
 | Method | Config command | Env var | Used by |
 |--------|---------------|---------|---------|
-| Browser login | `alchemy auth login` | -- | All commands (derives API key + access key from your account) |
-| API key | `alchemy config set api-key <key>` | `ALCHEMY_API_KEY` | `balance`, `tx`, `receipt`, `block`, `gas`, `logs`, `rpc`, `trace`, `debug`, `tokens`, `nfts`, `transfers`, `prices`, `portfolio`, `simulate`, `bundler`, `gas-manager`, `solana` |
-| Access key | `alchemy config set access-key <key>` | `ALCHEMY_ACCESS_KEY` | `apps` (all subcommands incl. `configured-networks`) |
-| Webhook key | `alchemy config set webhook-api-key <key>` | `ALCHEMY_WEBHOOK_API_KEY` | `webhooks` |
-| x402 wallet | `alchemy wallet generate` then `alchemy config set x402 true` | `ALCHEMY_WALLET_KEY` | `balance`, `tx`, `block`, `rpc`, `trace`, `debug`, `tokens`, `nfts`, `transfers` |
+| Browser login | `alchemy auth login` | -- | All commands (covers both RPC/Data and Admin) |
+| API key | `alchemy config set api-key <key>` | `ALCHEMY_API_KEY` | RPC/Data commands (`evm rpc`, `evm data`, `evm tx`, `solana rpc`, etc.) |
+| Webhook key | `alchemy config set webhook-api-key <key>` | `ALCHEMY_WEBHOOK_API_KEY` | `webhook` |
+| x402 wallet (EVM) | `alchemy wallet connect --mode local --chain evm` then `alchemy config set x402 true` | `ALCHEMY_WALLET_KEY` | RPC and Data commands when `--x402` is active |
 
-`alchemy network list` and `alchemy version` / `update-check` need no auth.
+`alchemy evm network list` / `alchemy solana network list` and `alchemy version` / `update-check` need no auth.
 
 ### Selecting a default app
 
-Many `apps` subcommands (and the access-key gated flows) operate on a "default app." If you see `APP_REQUIRED` in an error response, set one:
+Many `app` subcommands operate on a "default app." If you see `APP_REQUIRED` in an error response, select one:
 
 ```bash
-alchemy --json --no-interactive apps select <id>
+alchemy --json --no-interactive app select <id>
 # or equivalently
 alchemy --json --no-interactive config set app <id>
 ```
 
-Get API/access keys at [dashboard.alchemy.com](https://dashboard.alchemy.com/).
+Get an Alchemy account at [dashboard.alchemy.com](https://dashboard.alchemy.com/).
 
 ## Task-to-command map
 
-### Node (EVM)
+### EVM — onchain reads
 
 | Task | Command |
 |------|---------|
-| ETH balance | `alchemy balance <address>` |
-| Transaction details | `alchemy tx <hash>` |
-| Transaction receipt | `alchemy receipt <hash>` |
-| Block details | `alchemy block <number\|latest>` |
-| Gas prices | `alchemy gas` |
-| Event logs | `alchemy logs --address <addr> --from-block <n> --to-block <n>` |
-| Raw JSON-RPC | `alchemy rpc <method> [params...]` |
-| Trace methods | `alchemy trace <method> [params...]` |
-| Debug methods | `alchemy debug <method> [params...]` |
+| Native balance (ETH, MATIC, ...) | `alchemy evm data balance <address>` |
+| Transaction details | `alchemy evm tx <hash>` |
+| Transaction receipt | `alchemy evm receipt <hash>` |
+| Block details | `alchemy evm block <number\|latest>` |
+| Gas prices | `alchemy evm gas` |
+| Event logs | `alchemy evm logs --address <addr> --from-block <n> --to-block <n>` |
+| Raw JSON-RPC | `alchemy evm rpc <method> [params...]` |
+| Trace methods | `alchemy evm trace <method> [params...]` |
+| Debug methods | `alchemy evm debug <method> [params...]` |
+| Contract view/pure call | `alchemy evm contract read <address> <function> [--args ...] [--abi-file <path>]` |
 
-### Data
+### EVM — Data API
 
 | Task | Command |
 |------|---------|
-| ERC-20 balances | `alchemy tokens balances <address>` |
-| ERC-20 balances (formatted) | `alchemy tokens balances <address> --metadata` |
-| Token metadata | `alchemy tokens metadata <contract>` |
-| Token allowance | `alchemy tokens allowance --owner <addr> --spender <addr> --contract <addr>` |
-| List owned NFTs | `alchemy nfts <address> [--limit <n>] [--page-key <key>]` |
-| NFT metadata | `alchemy nfts metadata --contract <addr> --token-id <id>` |
-| NFT contract metadata | `alchemy nfts contract <address>` |
-| Transfer history | `alchemy transfers <address> --category erc20,erc721,erc1155,external,internal,specialnft [--from-block <n>] [--to-block <n>] [--max-count <n>] [--page-key <key>]` |
-| Spot prices by symbol | `alchemy prices symbol ETH,USDC` |
-| Spot prices by address | `alchemy prices address --addresses '<json>'` |
-| Historical prices | `alchemy prices historical --body '<json>'` |
-| Cross-network token portfolio | `alchemy portfolio tokens --body '<json>'` |
-| Token balances by address/network pairs | `alchemy portfolio token-balances --body '<json>'` |
-| Cross-network NFT portfolio | `alchemy portfolio nfts --body '<json>'` |
-| NFT contracts by address/network pairs | `alchemy portfolio nft-contracts --body '<json>'` |
-| Simulate single tx (asset deltas) | `alchemy simulate asset-changes --tx '<json>' [--block-tag <tag>]` |
-| Simulate single tx (execution trace) | `alchemy simulate execution --tx '<json>' [--block-tag <tag>]` |
-| Simulate bundle (asset deltas) | `alchemy simulate asset-changes-bundle --txs '<json-array>' [--block-tag <tag>]` |
-| Simulate bundle (execution trace) | `alchemy simulate execution-bundle --txs '<json-array>' [--block-tag <tag>]` |
+| ERC-20 balances | `alchemy evm data tokens balances <address>` |
+| ERC-20 balances (formatted) | `alchemy evm data tokens balances <address> --metadata` |
+| Token metadata | `alchemy evm data tokens metadata <contract>` |
+| Token allowance | `alchemy evm data tokens allowance --owner <addr> --spender <addr> --contract <addr>` |
+| List owned NFTs | `alchemy evm data nfts <address> [--limit <n>] [--page-key <key>]` |
+| NFT metadata | `alchemy evm data nfts metadata --contract <addr> --token-id <id>` |
+| NFT contract metadata | `alchemy evm data nfts contract <address>` |
+| Asset transfer history | `alchemy evm data history <address> [--from-block <n>] [--to-block <n>] [--max-count <n>] [--page-key <key>]` |
+| Spot prices by symbol | `alchemy evm data price symbol ETH,USDC` |
+| Spot prices by address | `alchemy evm data price address --addresses '<json>'` |
+| Historical prices | `alchemy evm data price historical --body '<json>'` |
+| Cross-network token portfolio | `alchemy evm data portfolio tokens --body '<json>'` |
+| Token balances by address/network pairs | `alchemy evm data portfolio token-balances --body '<json>'` |
+| Cross-network NFT portfolio | `alchemy evm data portfolio nfts --body '<json>'` |
+| NFT contracts by address/network pairs | `alchemy evm data portfolio nft-contracts --body '<json>'` |
+
+### EVM — Simulation
+
+| Task | Command |
+|------|---------|
+| Simulate single tx (asset deltas) | `alchemy evm simulate asset-changes --tx '<json>' [--block-tag <tag>]` |
+| Simulate single tx (execution trace) | `alchemy evm simulate execution --tx '<json>' [--block-tag <tag>]` |
+| Simulate bundle (asset deltas) | `alchemy evm simulate asset-changes-bundle --txs '<json-array>' [--block-tag <tag>]` |
+| Simulate bundle (execution trace) | `alchemy evm simulate execution-bundle --txs '<json-array>' [--block-tag <tag>]` |
+
+### EVM — wallet-signed transactions
+
+Wallet-signed EVM actions return a smart wallet **call ID**. Use `alchemy evm status <call-id-or-tx-hash>` to check either value. Use `--gas-sponsored` and `--gas-policy-id <id>` on supported actions to request gas sponsorship; set defaults with `alchemy config set evm-gas-sponsored true` and `alchemy config set evm-gas-policy-id <id>`.
+
+| Task | Command |
+|------|---------|
+| Send native token | `alchemy evm send <to> <amount> [-n <network>]` |
+| Send ERC-20 | `alchemy evm send <to> <amount> --token <token-address>` |
+| Execute a contract function | `alchemy evm contract call <address> <function> [--args ...] [--abi-file <path>\|--abi '<json>'] [--value <wei>]` |
+| Approve / revoke / reset ERC-20 allowance | `alchemy evm approve <spender-address> --token-address <addr> [--amount <n>\|--unlimited\|--revoke]` |
+| Quote same-chain swap | `alchemy evm swap quote --from <token> --to <token> --amount <n>` |
+| Execute same-chain swap | `alchemy evm swap execute --from <token> --to <token> --amount <n>` |
+| Check call / tx status | `alchemy evm status <call-id-or-tx-hash>` |
+
+Native token address for swaps: `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`.
+
+Most wallet-signed EVM commands accept `--signer session|local` to override the active signer for that invocation. When both signers are configured and no active one is chosen, the CLI defaults to `session` and prints a warning.
 
 ### Solana
+
+Solana transaction commands use a local Solana wallet (`alchemy wallet connect --mode local --chain solana`). Use `--fee-sponsored` and `--fee-policy-id <id>` on supported actions to request fee sponsorship; persist defaults with `alchemy config set solana-fee-sponsored true` / `alchemy config set solana-fee-policy-id <id>`.
 
 | Task | Command |
 |------|---------|
 | Solana JSON-RPC | `alchemy solana rpc <method> [params...]` |
 | Solana DAS (NFTs/assets) | `alchemy solana das <method> '<json>'` |
+| Send native SOL | `alchemy solana send <to> <amount> [-n solana-mainnet]` |
+| Approve SPL token delegate | `alchemy solana delegate approve --token-account <addr> --mint <addr> --delegate <addr> --amount <n> --decimals <n>` |
+| Revoke SPL token delegate | `alchemy solana delegate revoke --token-account <addr>` |
+| Check Solana tx status | `alchemy solana status <signature>` |
+| List program accounts | `alchemy solana program accounts <program-id> [--filters '<json>'] [--encoding <enc>] [--limit <n>]` |
+| Show Solana account | `alchemy solana program account <address>` |
+| Show Solana program metadata | `alchemy solana program show <program-id>` |
+| List Solana network IDs | `alchemy solana network list` |
 
-### Webhooks
+`alchemy solana swap` is reserved for future support and is not implemented.
 
-| Task | Command |
-|------|---------|
-| List webhooks | `alchemy webhooks list` |
-| Create webhook | `alchemy webhooks create --body '<json>' [--dry-run]` |
-| Update webhook | `alchemy webhooks update --body '<json>' [--dry-run]` |
-| Delete webhook | `alchemy webhooks delete <id> [--yes] [--dry-run]` |
-| Get address-activity webhook addresses | `alchemy webhooks addresses <id>` |
-| Get NFT-activity webhook filters | `alchemy webhooks nft-filters <id>` |
+### Cross-chain
 
-### Account abstraction (ERC-4337)
-
-| Task | Command |
-|------|---------|
-| Send a UserOperation | `alchemy bundler send-user-operation --user-op '<json>' --entry-point <addr>` |
-| Estimate UserOperation gas | `alchemy bundler estimate-user-operation-gas --user-op '<json>' --entry-point <addr> [--state-override '<json>']` |
-| Get UserOperation receipt | `alchemy bundler get-user-operation-receipt --user-op-hash <hash>` |
-| Request gas + paymaster data | `alchemy gas-manager request-gas-and-paymaster --body '<json>'` |
-| Request paymaster token quote | `alchemy gas-manager request-paymaster-token-quote --body '<json>'` |
-
-### Wallet (x402)
+Bridge supports EVM mainnets. For same-chain token exchanges, use `alchemy evm swap`.
 
 | Task | Command |
 |------|---------|
-| Generate a new wallet | `alchemy wallet generate` |
-| Import a wallet from a key file | `alchemy wallet import <path>` |
-| Show the locally configured wallet address | `alchemy wallet address` |
+| Quote a bridge | `alchemy xchain bridge quote --from <token> --to <token> --amount <n> --to-network <network>` |
+| Execute a bridge | `alchemy xchain bridge execute --from <token> --to <token> --amount <n> --to-network <network>` |
 
-### App management
+Source network comes from `-n, --network`.
+
+### Wallets and signing
 
 | Task | Command |
 |------|---------|
-| List apps | `alchemy apps list [--cursor <c>] [--limit <n>] [--all] [--search <q>] [--id <appId>]` |
-| Get app details | `alchemy apps get <id>` |
-| Create app | `alchemy apps create --name "My App" --networks eth-mainnet [--description <desc>] [--products <ids>] [--dry-run]` |
-| Update app metadata | `alchemy apps update <id> --name "New Name" [--description <desc>] [--dry-run]` |
-| Update app network allowlist | `alchemy apps networks <id> --networks eth-mainnet,base-mainnet [--dry-run]` |
-| Update app address allowlist | `alchemy apps address-allowlist <id> --addresses 0xAA,0xBB [--dry-run]` |
-| Update app origin allowlist | `alchemy apps origin-allowlist <id> --origins https://a.com,https://b.com [--dry-run]` |
-| Update app IP allowlist | `alchemy apps ip-allowlist <id> --ips 1.2.3.4,5.6.7.8 [--dry-run]` |
-| Delete app | `alchemy apps delete <id> [--yes] [--dry-run]` |
-| Select default app | `alchemy apps select <id>` (equivalent to `alchemy config set app <id>`) |
-| List networks configured for an app | `alchemy apps configured-networks [--app-id <id>]` |
-| List Admin API chain identifiers (for `apps create`/`update`) | `alchemy apps chains` |
-| List all RPC network slugs (for `--network`) | `alchemy network list [--mainnet-only] [--testnet-only] [--search <term>]` |
+| Connect a wallet (session) | `alchemy wallet connect --mode session` |
+| Connect local EVM wallet (import private key file) | `alchemy wallet connect --mode local --chain evm --import <path>` |
+| Connect local Solana wallet | `alchemy wallet connect --mode local --chain solana` |
+| Show wallet status | `alchemy wallet status [--verify]` |
+| Show configured wallet addresses | `alchemy wallet address` |
+| Render an address as a QR code | `alchemy wallet qr` |
+| Pick active signer for EVM txns | `alchemy wallet use <session\|local>` |
+| Disconnect / revoke wallet | `alchemy wallet disconnect` |
 
-### CLI admin
+### Webhook (Notify)
+
+| Task | Command |
+|------|---------|
+| List webhooks | `alchemy webhook list` |
+| Create webhook | `alchemy webhook create --body '<json>' [--dry-run]` |
+| Update webhook | `alchemy webhook update --body '<json>' [--dry-run]` |
+| Delete webhook | `alchemy webhook delete <id> [--yes] [--dry-run]` |
+| Get address-activity webhook addresses | `alchemy webhook addresses <id>` |
+| Get NFT-activity webhook filters | `alchemy webhook nft-filters <id>` |
+
+### App management (Admin API)
+
+| Task | Command |
+|------|---------|
+| List apps | `alchemy app list [--cursor <c>] [--limit <n>] [--all] [--search <q>] [--id <appId>]` |
+| Get app details | `alchemy app get <id>` |
+| Create app | `alchemy app create --name "My App" --networks eth-mainnet [--description <desc>] [--products <ids>] [--dry-run]` |
+| Update app metadata | `alchemy app update <id> --name "New Name" [--description <desc>] [--dry-run]` |
+| Update app network allowlist | `alchemy app networks <id> --networks eth-mainnet,base-mainnet [--dry-run]` |
+| Update app address allowlist | `alchemy app address-allowlist <id> --addresses 0xAA,0xBB [--dry-run]` |
+| Update app origin allowlist | `alchemy app origin-allowlist <id> --origins https://a.com,https://b.com [--dry-run]` |
+| Update app IP allowlist | `alchemy app ip-allowlist <id> --ips 1.2.3.4,5.6.7.8 [--dry-run]` |
+| Delete app | `alchemy app delete <id> [--yes] [--dry-run]` |
+| Select default app | `alchemy app select <id>` (equivalent to `alchemy config set app <id>`) |
+| List networks configured for an app | `alchemy app configured-networks [--app-id <id>]` |
+| List Admin API chain identifiers (for `app create`/`update`) | `alchemy app chains` |
+| List EVM RPC network slugs (for `--network`) | `alchemy evm network list [--mainnet-only] [--testnet-only] [--search <term>]` |
+
+### CLI admin and utilities
 
 | Task | Command |
 |------|---------|
@@ -209,6 +250,8 @@ Get API/access keys at [dashboard.alchemy.com](https://dashboard.alchemy.com/).
 | View config | `alchemy config list` |
 | Reset config | `alchemy config reset --yes` |
 | CLI version | `alchemy version` |
+| Install MCP / Skills for a client | `alchemy install mcp` / `alchemy install skills` |
+| Shell completions | `alchemy completions <bash\|zsh\|fish>` |
 
 ## Global flags
 
@@ -218,9 +261,9 @@ Get API/access keys at [dashboard.alchemy.com](https://dashboard.alchemy.com/).
 | `--no-interactive` | Disable prompts and REPL |
 | `-n, --network <network>` | Target network (default: `eth-mainnet`, env: `ALCHEMY_NETWORK`) |
 | `--api-key <key>` | Override API key per command (env: `ALCHEMY_API_KEY`) |
-| `--access-key <key>` | Override access key per command (env: `ALCHEMY_ACCESS_KEY`) |
 | `--x402` | Use x402 wallet-based gateway auth for this command |
-| `--wallet-key-file <path>` | Path to wallet private key file (for x402) |
+| `--wallet-key-file <path>` | Path to an EVM wallet private key file (for x402) |
+| `--solana-wallet-key-file <path>` | Path to a Solana wallet key file |
 | `--timeout <ms>` | Request timeout in milliseconds |
 | `-q, --quiet` | Suppress non-essential output |
 | `--verbose` | Log request/response details to stderr |
@@ -236,16 +279,14 @@ Errors return structured JSON on stderr. Each error has a `code`, an `exitCode` 
 |------|------|-----------|----------|
 | `AUTH_REQUIRED` | 3 | No | Run `alchemy auth login`, or set `ALCHEMY_API_KEY` / `alchemy config set api-key <key>` |
 | `INVALID_API_KEY` | 3 | No | Check the API key; set a valid one with `alchemy config set api-key <key>` |
-| `ACCESS_KEY_REQUIRED` | 3 | No | Set `ALCHEMY_ACCESS_KEY` or run `alchemy config set access-key <key>` |
-| `INVALID_ACCESS_KEY` | 3 | No | Check the access key at [dashboard.alchemy.com](https://dashboard.alchemy.com/) |
-| `APP_REQUIRED` | 3 | No | Select a default app: `alchemy apps select <id>` (or `alchemy config set app <id>`) |
+| `APP_REQUIRED` | 3 | No | Select a default app: `alchemy app select <id>` (or `alchemy config set app <id>`) |
 | `NETWORK_NOT_ENABLED` | 3 | No | Enable the target network for your app at dashboard.alchemy.com |
-| `SETUP_REQUIRED` | 3 | No | Run `alchemy --json setup status` and follow `nextCommands` |
+| `SETUP_REQUIRED` | 3 | No | Run `alchemy --json doctor` and follow `nextCommands` |
 | `PAYMENT_REQUIRED` | 9 | No | Fund x402 wallet or switch to API key auth |
 | `RATE_LIMITED` | 5 | Yes | Wait and retry with backoff; consider upgrading your plan |
 | `NETWORK_ERROR` | 6 | Yes | Check connection and retry |
 | `RPC_ERROR` | 7 | No | Check method, params, and network; verify API key has access |
-| `ADMIN_API_ERROR` | 8 | No | Check error message; verify access key permissions |
+| `ADMIN_API_ERROR` | 8 | No | Check the error message; admin commands require an authenticated browser session |
 | `NOT_FOUND` | 4 | No | Verify the resource identifier (address, hash, id) is correct |
 | `INVALID_ARGS` | 2 | No | Check command usage via `alchemy --json help <command>` |
 | `INTERNAL_ERROR` | 1 | No | Unexpected error; retry or report a bug |
@@ -271,12 +312,12 @@ If the user is starting an app-code project and `$ALCHEMY_API_KEY` isn't set in 
 KEY="$(alchemy --no-interactive --json --reveal config get api-key 2>/dev/null | jq -r .value)"
 
 # 2. If empty/null, run the interactive flow.
-#    Note: auth login opens a browser and apps select shows a picker, so do NOT
+#    Note: auth login opens a browser and app select shows a picker, so do NOT
 #    pass --no-interactive here. If you already know the app id, pass it
-#    explicitly to skip the picker: `alchemy --no-interactive --json apps select <id>`.
+#    explicitly to skip the picker: `alchemy --no-interactive --json app select <id>`.
 if [ -z "$KEY" ] || [ "$KEY" = "null" ]; then
   alchemy auth login              # opens browser; sets up account credentials
-  alchemy --json apps select      # interactive picker (omit --no-interactive so it can render)
+  alchemy --json app select       # interactive picker (omit --no-interactive so it can render)
   KEY="$(alchemy --no-interactive --json --reveal config get api-key | jq -r .value)"
 fi
 


### PR DESCRIPTION
Weekly sync from merged docs changes (week of 2026-05-06 → 2026-05-13).

## Docs PRs covered

Material changes:

- [#1173](https://github.com/alchemyplatform/docs/pull/1173) — Add `getTransactionsForAddress` Solana API spec (new JSON-RPC method)
- [#1266](https://github.com/alchemyplatform/docs/pull/1266) — Base Flashblocks subscriptions switched to event-based pricing
- [#1281](https://github.com/alchemyplatform/docs/pull/1281) — Docs for 5 new Bitcoin-ecosystem chains (BCH mainnet/testnet, LTC mainnet/testnet, DOGE mainnet) + UTXO REST API
- [#1282](https://github.com/alchemyplatform/docs/pull/1282) — Alchemy CLI command structure rewrite (`evm`, `solana`, `xchain`, `wallet`, `app`, `webhook` groups)
- [#1285](https://github.com/alchemyplatform/docs/pull/1285) — v5 wallet API examples switched from `transactionHash` to call ID for tracking sends
- [#1287](https://github.com/alchemyplatform/docs/pull/1287) — Solana DAS Try It defaults fixed for `getTokenAccounts` and `searchAssets` (phantom params removed, real param set documented)

Non-material (skipped):

- #1283 — wallet-api spec zod regen (schema tightening, no user-facing API surface change)
- #1284 — weekly node-upgrade changelog
- #1291, #1292, #1295 — UTXO migration guide / overview page / title rename (content positioning, not API surface)

## Skills files updated

- `skills/alchemy-cli/SKILL.md` — full command-tree refresh for PR #1282. Updated every task-to-command row (`alchemy balance` → `alchemy evm data balance`, `alchemy tx` → `alchemy evm tx`, `alchemy webhooks` → `alchemy webhook`, `alchemy apps` → `alchemy app`, …). Added EVM wallet-signed transactions, swaps, Solana sends/delegate/program, cross-chain bridge, and the new `wallet connect/use/status` flow. Replaced `setup status` with `doctor`/`config status`. Dropped `--access-key` (now derived from `auth login`).
- `skills/alchemy-api/references/operational-supported-networks.md` — added `bitcoincash-mainnet`, `bitcoincash-testnet`, `litecoin-mainnet`, `litecoin-testnet`, `dogecoin-mainnet`, `bitcoin-testnet4` to the Data API network list. Added a "Recently Added" section explaining the UTXO REST API surface across all 7 UTXO networks.
- `skills/alchemy-api/references/solana-das-api.md` — rewrote `searchAssets` params section to mark `ownerAddress` required, add `tokenType` (with case-sensitivity note), document `delegate` (not `delegateAddress`), call out `interface`/`tokenType` mutual exclusion and pagination strategy rules. Added a brand new `getTokenAccounts` section since it's now part of the DAS spec.
- `skills/alchemy-api/references/solana-rpc.md` — added `getTransactionsForAddress` method section with full param table and the rationale for preferring it over `getSignaturesForAddress` + per-signature `getTransaction`.
- `skills/alchemy-api/references/wallets-wallet-apis.md` — added "Tracking Sends: Call ID, Not Transaction Hash" subsection covering the v5 SDK call-ID-first pattern.
- `skills/alchemy-api/references/operational-rate-limits-and-compute-units.md` — added Webhooks/Subscriptions pricing section noting the Flashblocks event-based pricing exception (40 CU / 60 CU) vs the default 0.04 CU / byte.

## Material changes

- **New chains**: Bitcoin Cash mainnet+testnet, Litecoin mainnet+testnet, Dogecoin mainnet. All share Bitcoin Core JSON-RPC method set and the new UTXO REST API (Trezor Blockbook-derived).
- **New REST surface**: UTXO REST API exposed across 7 UTXO networks at `https://{network}.g.alchemy.com/v2/{apiKey}/api/v2/...`.
- **New JSON-RPC method**: Solana `getTransactionsForAddress` returns transactions for an address with status/slot/blockTime/tokenAccounts filters and pagination.
- **CLI surface rewrite**: every command moved under chain/product groups (`evm`, `solana`, `xchain`, `wallet`, `app`, `webhook`). Added wallet-signed sends, swaps, bridges, Solana sends/delegate/program.
- **DAS param corrections**: `getTokenAccounts` and `searchAssets` had phantom params removed (`programId`, `commitment`, `dataSlice`, `encoding`, `delegateAddress`, `mutable`) and required fields tightened (`ownerAddress` required on both).
- **Wallet API pattern**: tracking sends via call ID, not `receipts[0].transactionHash`.
- **Pricing**: Base Flashblocks subscriptions (`newFlashblockTransactions`, `newFlashblocks`) now event-priced (40 / 60 CU per event) instead of byte-priced.