### PR TITLE
feat(ecosystem): add Monad skill (concepts, gas, addresses, HyperIndex)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "alchemy",
   "skills": [
-    "./skills/ecosystem/allium"
+    "./skills/ecosystem/allium",
+    "./skills/ecosystem/monad"
   ]
 }

--- a/skills/ecosystem/README.md
+++ b/skills/ecosystem/README.md
@@ -40,7 +40,8 @@ When adding a new partner skill, add an entry to `plugin.json` so it gets instal
 
 ## Current partners
 
-- **Allium** — wallet PnL (current + historical, by-wallet and by-token), holdings timeseries, Hyperliquid trading data (info, fills, orders, orderbook), and custom SQL analytics over Allium's data warehouse ([`./skills/allium/`](./skills/allium/)). Curated subset of [allium-labs/skills](https://github.com/allium-labs/skills) — overlapping endpoints (prices, token metadata, current balances, transactions, NFT) are intentionally omitted and routed to first-party Alchemy skills.
+- **Allium** — wallet PnL (current + historical, by-wallet and by-token), holdings timeseries, Hyperliquid trading data (info, fills, orders, orderbook), and custom SQL analytics over Allium's data warehouse ([`./allium/`](./allium/)). Curated subset of [allium-labs/skills](https://github.com/allium-labs/skills) — overlapping endpoints (prices, token metadata, current balances, transactions, NFT) are intentionally omitted and routed to first-party Alchemy skills.
+- **Monad** — building on Monad mainnet/testnet: architecture concepts (async execution, parallel execution, EIP-7702), gas pricing rules (`gas_limit` not `gas_used`), canonical contract addresses, and HyperIndex (Envio Cloud) on-chain event indexing ([`./monad/`](./monad/)). Curated subset of [therealharpaljadeja/monskills](https://github.com/therealharpaljadeja/monskills) — Alchemy's Monad RPC, Account Kit / Bundler / Gas Manager are routed back to first-party `alchemy-*` skills.
 
 ## Routing for agents
 
@@ -52,5 +53,6 @@ When adding a new partner skill, add an entry to `plugin.json` so it gets instal
 | Holdings timeseries history | `allium` |
 | Hyperliquid trading data (fills, orders, positions, orderbook) | `allium` |
 | Custom SQL on a blockchain data warehouse (DeFi, NFT, bridges, MEV, Solana staking) | `allium` |
+| Monad-specific concepts, gas pricing, canonical addresses, HyperIndex event indexing | `monad` |
 
 See each skill's `SKILL.md` for its exact `scope_in` / `scope_out`.

--- a/skills/ecosystem/monad/LICENSE.txt
+++ b/skills/ecosystem/monad/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2026 Harpalsinh Jadeja
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ecosystem/monad/SKILL.md
+++ b/skills/ecosystem/monad/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: monad
+description: Build apps on Monad — high-throughput EVM L1 with 400ms blocks, 800ms finality, async execution, native EIP-7702 support, and a unique gas pricing model where users pay for `gas_limit` not `gas_used`. Use for Monad architecture concepts, canonical contract addresses, gas pricing rules, and HyperIndex (Envio Cloud) indexing of on-chain events. For Alchemy's Monad RPC, Account Kit (agent wallets), Bundler, or Gas Manager — use `alchemy-cli` (live), `alchemy-api` (with API key), or `alchemy-agentic-gateway` (without). Curated subset of `therealharpaljadeja/monskills`.
+license: MIT
+compatibility: Public on-chain data; references only. Some recipes call Envio Cloud or `pnpx envio` for indexing — those need `envio-cloud` and `gh` installed and logged in.
+metadata:
+  author: therealharpaljadeja
+  version: "0.1"
+  provider: monad
+  partner: "true"
+---
+
+# Monad
+
+Curated entry point into the [Monskills](https://skills.devnads.com) catalog by [Harpalsinh Jadeja](https://github.com/therealharpaljadeja). Covers Monad-specific topics — async execution, the `gas_limit` pricing model, canonical addresses, and HyperIndex indexing — that complement Alchemy's first-party Monad surfaces (JSON-RPC, Account Kit / Bundler / Gas Manager for agent wallets and sponsored transactions).
+
+| | |
+| --- | --- |
+| **Chains** | Monad mainnet, Monad testnet |
+| **Block time** | ~400ms |
+| **Finality** | ~800ms |
+| **Throughput** | 10,000 tps |
+| **EVM** | Fully compatible (no contract changes needed). Native EIP-7702. |
+| **Gas pricing** | Charged on `gas_limit`, not `gas_used` — wrong limits cost users real money |
+| **Explorers** | monadscan.com (mainnet), testnet.monadscan.com (testnet) |
+| **Upstream** | `therealharpaljadeja/monskills` — `npx skills add therealharpaljadeja/monskills` for the full catalog |
+
+## When to use this skill
+
+Use `monad` when **any** of the following apply:
+
+- Building an app on Monad mainnet or testnet
+- The user needs to understand Monad-specific behavior that differs from Ethereum — async execution, parallel execution, block states (`latest`/`safe`/`finalized`), reserve balance (10 MON floor per EOA), or native EIP-7702 delegation
+- Setting gas limits on Monad — `gas_limit` is what users pay, **not** actual `gas_used`. Wrong limits cost real money. Cold state access is 3-4x more expensive than Ethereum; precompiles are 2-5x more expensive.
+- Looking up canonical contract addresses on Monad (Wrapped MON, ERC-4337 EntryPoint, Multicall3, Safe, Permit2, bridged stables/ETH/BTC, ERC-8004 agent identity registry, etc.)
+- Indexing on-chain events on Monad — HyperIndex deployed via `envio-cloud` for activity feeds, leaderboards, transaction history, analytics dashboards
+- Choosing a chain to build on — Monad is high-throughput EVM with full Solidity compatibility
+
+## When to use a different skill
+
+| Need | Use instead |
+| --- | --- |
+| Live JSON-RPC queries to Monad from this agent session | `alchemy-cli` (CLI) or `alchemy-mcp` (MCP) — Alchemy provides Monad mainnet RPC |
+| App code making JSON-RPC calls to Monad | `alchemy-api` (with API key) or `alchemy-agentic-gateway` (without) |
+| Account Kit / Bundler / Smart Account setup for agent wallets on Monad with full ERC-4337 infrastructure | `alchemy-cli` (live) or `alchemy-api` (app code) |
+| Gas sponsorship / paymaster policies on Monad | `alchemy-cli` (live) or `alchemy-api` (Gas Manager) |
+| Token metadata, prices, or portfolio reads on Monad | Not supported by Alchemy Token / Prices / Portfolio APIs on Monad yet — use the [`indexer`](./references/indexer.md) (HyperIndex via Envio Cloud) for on-chain data, or query Monad-native protocols directly |
+| NFT marketplace data, listings, or fulfillment | `opensea-api` / `opensea-marketplace` (where they support Monad) |
+| Fiat → MON on-ramp | `moonpay` ecosystem skill |
+
+## Setup
+
+This skill is documentation-only — no auth required to read it. The recipes inside link to specific tools (e.g. `envio-cloud`, `cast`, `pnpx envio`) and call out their prerequisites in line.
+
+For the **full** monskills catalog (scaffold, wallet, wallet-integration, vercel-deploy, feedback, etc.), install the upstream:
+
+```bash
+npx skills add therealharpaljadeja/monskills
+```
+
+## References
+
+Detailed coverage per topic lives in [`./references/`](./references/):
+
+- [`concepts.md`](./references/concepts.md) — Monad architecture (async execution, parallel execution, block states, reserve balance, EIP-7702, real-time data sources)
+- [`gas.md`](./references/gas.md) — Gas pricing on Monad (charged on `gas_limit`, base fee controller, opcode repricing, developer guidelines)
+- [`addresses.md`](./references/addresses.md) — Canonical contract addresses on Monad mainnet (ERC-4337 EntryPoint, Safe, Multicall3, Permit2, bridged assets, ERC-8004 agent registry)
+- [`indexer.md`](./references/indexer.md) — HyperIndex on Envio Cloud — initialize and deploy an indexer for Monad smart contract events
+
+## Source
+
+Curated from upstream [`therealharpaljadeja/monskills`](https://github.com/therealharpaljadeja/monskills) under MIT license (Copyright 2026 Harpalsinh Jadeja). Upstream is the source of truth — install it directly for the full catalog.

--- a/skills/ecosystem/monad/agents/openai.yaml
+++ b/skills/ecosystem/monad/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Monad"
+  short_description: "Build on Monad — concepts, gas, addresses, HyperIndex"
+  default_prompt: "Use the monad ecosystem skill for Monad-specific concepts (async execution, EIP-7702), gas pricing rules (charged on gas_limit), canonical addresses, and HyperIndex event indexing."

--- a/skills/ecosystem/monad/references/addresses.md
+++ b/skills/ecosystem/monad/references/addresses.md
@@ -1,0 +1,115 @@
+# Canonical Contract Addresses on Monad
+
+> **CRITICAL:** Always verify with a network explorer before interacting. Never hallucinate an address — wrong addresses can mean **loss of funds**.
+
+| Network | Explorer | RPC (public) |
+| --- | --- | --- |
+| Monad Mainnet | `monadscan.com` | `https://rpc.monad.xyz` |
+| Monad Testnet | `testnet.monadscan.com` | `https://testnet-rpc.monad.xyz` |
+
+If the user hasn't specified mainnet vs testnet, **ask**. Do not provide a mainnet address when the user asked for a testnet address (or vice versa).
+
+For Alchemy's authenticated Monad endpoints (rate-limited and reliable), use `alchemy-cli` or `alchemy-api`.
+
+## Verifying an address has code
+
+If Foundry is installed:
+
+```bash
+# Mainnet
+cast code <SMART_CONTRACT_ADDRESS> --rpc-url https://rpc.monad.xyz
+
+# Testnet
+cast code <SMART_CONTRACT_ADDRESS> --rpc-url https://testnet-rpc.monad.xyz
+```
+
+Otherwise call `eth_getCode` directly via JSON-RPC.
+
+## Canonical contracts (Monad mainnet)
+
+| Name | Address |
+| --- | --- |
+| Wrapped MON (`WMON`) | `0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A` |
+| Create2Deployer | `0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2` |
+| CreateX | `0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed` |
+| ERC-2470 Singleton Factory | `0xce0042b868300000d44a59004da54a005ffdcf9f` |
+| **ERC-4337 EntryPoint v0.6** | `0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789` |
+| ERC-4337 SenderCreator v0.6 | `0x7fc98430eAEdbb6070B35B39D798725049088348` |
+| **ERC-4337 EntryPoint v0.7** | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` |
+| ERC-4337 SenderCreator v0.7 | `0xEFC2c1444eBCC4Db75e7613d20C6a62fF67A167C` |
+| ERC-6492 UniversalSigValidator | `0xdAcD51A54883eb67D95FAEb2BBfdC4a9a6BD2a3B` |
+| Foundry Deterministic Deployer | `0x4e59b44847b379578588920ca78fbf26c0b4956c` |
+| Multicall3 | `0xcA11bde05977b3631167028862bE2a173976CA11` |
+| MultiSend | `0x998739BFdAAdde7C933B942a68053933098f9EDa` |
+| MultiSendCallOnly | `0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B` |
+| Permit2 | `0x000000000022d473030f116ddee9f6b43ac78ba3` |
+| Safe | `0x69f4D1788e39c87893C980c06EdF4b7f686e2938` |
+| SafeL2 | `0xfb1bffC9d739B8D520DaF37dF666da4C687191EA` |
+| SafeSingletonFactory | `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` |
+| SimpleAccount | `0x68641DE71cfEa5a5d0D29712449Ee254bb1400C2` |
+| Simple7702Account | `0xe6Cae83BdE06E4c305530e199D7217f42808555B` |
+| Sub Zero VanityMarket | `0x000000000000b361194cfe6312EE3210d53C15AA` |
+| Zoltu Deterministic Deployment Proxy | `0x7A0D94F55792C434d74a40883C6ed8545E406D12` |
+
+## ERC-8004 (AI agent identity registry — same on Monad mainnet and testnet)
+
+| Contract | Address |
+| --- | --- |
+| IdentityRegistry | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` |
+| ReputationRegistry | `0x8004BAa17C55a88189AE136b182e5fdA19dE9b63` |
+
+## Bridged stablecoins (Monad mainnet)
+
+| Symbol | Name | Address |
+| --- | --- | --- |
+| AUSD | Agora USD | `0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a` |
+| USDC | USD Coin | `0x754704Bc059F8C67012fEd69BC8A327a5aafb603` |
+| USDT0 | Tether USD | `0xe7cd86e13AC4309349F30B3435a9d337750fC82D` |
+| USD1 | USD1 | `0x111111d2bf19e43C34263401e0CAd979eD1cdb61` |
+| thBILL | Theo Short Duration UST Fund | `0xfDD22Ce6D1F66bc0Ec89b20BF16CcB6670F55A5a` |
+| wsrUSD | Wrapped srUSD | `0x4809010926aec940b550D34a46A52739f996D75D` |
+| yzUSD | Yuzu USD | `0x9dcB0D17eDDE04D27F387c89fECb78654C373858` |
+| syzUSD | Staked Yuzu USD | `0x484be0540aD49f351eaa04eeB35dF0f937D4E73f` |
+
+## Bridged ETH-related (Monad mainnet)
+
+| Symbol | Name | Address |
+| --- | --- | --- |
+| WETH | Wrapped Ether | `0xEE8c0E9f1BFFb4Eb878d8f15f368A02a35481242` |
+| ezETH | Renzo Restaked ETH | `0x2416092f143378750bb29b79eD961ab195CcEea5` |
+| wstETH | Lido Wrapped Staked ETH | `0x10Aeaf63194db8d453d4D85a06E5eFE1dd0b5417` |
+| weETH | Wrapped EtherFi ETH | `0xA3D68b74bF0528fdD07263c60d6488749044914b` |
+| pufETH | pufETH | `0x37D6382B6889cCeF8d6871A8b60E667115eDDBcF` |
+
+## Bridged BTC-related (Monad mainnet)
+
+| Symbol | Name | Address |
+| --- | --- | --- |
+| cbBTC | Coinbase Wrapped BTC | `0xd18B7EC58Cdf4876f6AFebd3Ed1730e4Ce10414b` |
+| WBTC | Wrapped Bitcoin | `0x0555E30da8f98308EdB960aa94C0Db47230d2B9c` |
+| LBTC | Lombard Staked Bitcoin | `0xecAc9C5F704e954931349Da37F60E39f515c11c1` |
+| BTC.b | BTC.b | `0xB0F70C0bD6FD87dbEb7C10dC692a2a6106817072` |
+| SolvBTC | Solv BTC | `0xaE4EFbc7736f963982aACb17EFA37fCBAb924cB3` |
+| xSolvBTC | xSolvBTC | `0xc99F5c922DAE05B6e2ff83463ce705eF7C91F077` |
+
+## MON on other chains
+
+| Name | Chain | Address |
+| --- | --- | --- |
+| WMON | Solana | `CrAr4RRJMBVwRsZtT62pEhfA9H5utymC2mVx8e7FreP2` |
+| WMON | Ethereum | `0x6917037f8944201b2648198a89906edf863b9517` |
+
+## Beyond the canonical set
+
+For protocol-specific addresses (DEXs, lending markets, etc.), check the official Monad repositories — they are versioned and curated:
+
+- **Protocols:** https://github.com/monad-crypto/protocols
+  Organized as `mainnet/<protocol>.jsonc` and `testnet/<protocol>.jsonc`. Each file has an `addresses` object with named entries.
+- **Token list:** https://github.com/monad-crypto/token-list
+  Per-token folders under `mainnet/` with address JSON.
+
+If an address isn't in the tables above or the upstream repos, **ask the user**. Do not hallucinate.
+
+## Upstream reference
+
+Full monskills `addresses/` skill: https://github.com/therealharpaljadeja/monskills/blob/main/addresses/SKILL.md

--- a/skills/ecosystem/monad/references/concepts.md
+++ b/skills/ecosystem/monad/references/concepts.md
@@ -1,0 +1,57 @@
+# Monad Architecture Concepts
+
+Monad is Ethereum-compatible (no Solidity changes required), but its architecture introduces behaviors that affect how apps must be built.
+
+## Quick reference
+
+| Concept | Summary |
+| --- | --- |
+| **Async execution** | Consensus and execution are decoupled. Block leaders propose blocks **before** executing them. State view is delayed by ~3 blocks. **Newly funded accounts need ~1.2s** before they can send transactions. |
+| **Parallel execution** | Optimistic concurrency. Transactions run in parallel where state-disjoint; conflicts re-run. Identical results to Ethereum. **No contract changes needed.** |
+| **Block states** | Proposed → Voted → Finalized → Verified. Maps to JSON-RPC tags `pending`/`latest` (proposed), `safe` (voted), `finalized` (committed). |
+| **Reserve balance** | EOAs maintain a **10 MON floor**. Low-balance accounts are limited to ~1 tx per 1.2s. Emptying transactions revert if they'd take the balance below 10 MON. |
+| **EIP-7702** | EOAs delegate to contracts for smart-wallet features (session keys, gas sponsorship, batch txs). 10 MON floor still applies. **No `CREATE`/`CREATE2` in delegated context.** |
+| **Real-time data** | Three sources: (1) Geth-compatible WebSocket — the default for most apps; (2) Monad extended WebSocket — richer event payloads; (3) Execution Events SDK — speculative pre-finality EVM traces. |
+
+## Block state → JSON-RPC tag mapping
+
+When making `eth_call` / `eth_getBlock*` / `eth_getBalance` and friends:
+
+| RPC tag | Monad state | Use when |
+| --- | --- | --- |
+| `pending` | Proposed (not yet voted) | Optimistic UI — show what's likely about to land |
+| `latest` | Proposed → executed (~3 block delay between proposal and visible state) | Default for most reads |
+| `safe` | Voted by validators | Defensive UI for high-value displays |
+| `finalized` | Finalized (committed by consensus) | Settlement guarantees, bridges, irrevocable actions |
+
+## Async execution gotchas
+
+The most common failure mode: **fund an account, then immediately try to send a tx — the tx fails**. State visibility lags execution by ~3 blocks (~1.2s). Wait one finalization cycle before relying on a balance change.
+
+Apps that show "funded ✓" → "send tx" UX should either:
+1. Poll `eth_getBalance` against `latest` until the balance reaches the expected value (1-2 seconds), OR
+2. Insert an explicit 1.5–2s delay between funding and dependent transactions.
+
+## EIP-7702 (delegated EOAs)
+
+EIP-7702 is natively supported on Monad mainnet from day one. An EOA signs a delegation to a smart contract — subsequent transactions from that EOA execute the contract's logic. This unlocks smart-wallet features (session keys, paymasters, batch calls) without migrating to a separate smart account address.
+
+Caveats:
+- The 10 MON reserve balance floor still applies to delegated EOAs.
+- `CREATE` and `CREATE2` are **not** available inside delegated execution. Use canonical factories (CreateX, Create2Deployer — see [`addresses.md`](./addresses.md)) for deterministic deployments.
+
+For Alchemy's ERC-4337 smart-account path (which is independent of EIP-7702 and uses a separate smart-account address), use `alchemy-cli` or `alchemy-api`.
+
+## Full upstream coverage
+
+Each concept has a detailed reference in upstream monskills:
+
+- async-execution.md — newly funded accounts, funding delays, 3-block state delay
+- parallel-execution.md — what changes (nothing) for existing Solidity
+- block-states.md — choosing between `latest` / `safe` / `finalized` tags
+- reserve-balance.md — 10 MON floor, emptying transactions, low-balance throttling
+- eip-7702.md — smart wallet delegation, session keys, gas sponsorship caveats
+- realtime-data.md — Geth WS vs Monad extended WS vs Execution Events SDK
+- execution-events.md — BLOCK_START / QC / FINALIZED lifecycle events
+
+Browse them via the `concepts/` skill in [`therealharpaljadeja/monskills`](https://github.com/therealharpaljadeja/monskills/tree/main/concepts).

--- a/skills/ecosystem/monad/references/gas.md
+++ b/skills/ecosystem/monad/references/gas.md
@@ -1,0 +1,107 @@
+# Gas Pricing on Monad
+
+Monad is EIP-1559 compatible but diverges from Ethereum in ways that **cost users real money** if ignored.
+
+## The critical difference: `gas_limit` is what users pay
+
+On Ethereum, users pay for gas **actually consumed**. On Monad, users pay based on the **gas limit** they set:
+
+```
+gas_paid = gas_limit * price_per_gas
+```
+
+This exists because block leaders build blocks **before** executing them (async execution), so actual gas usage isn't known at inclusion time — `gas_limit` is the contractually-committed price ceiling.
+
+**Implications for developers:**
+
+- Setting an unnecessarily high `gas_limit` directly costs users more MON.
+- For transactions with known fixed costs, **hardcode the limit**. Native MON transfers are always 21,000 — hardcode it; do not rely on `eth_estimateGas` (some wallets fall back to a much higher limit on estimation failure).
+- When you must estimate, keep the buffer small (≤10%).
+
+```typescript
+// Native transfer — hardcode the limit
+const tx = { to, value: parseEther("1.0"), gasLimit: 21_000n };
+
+// Contract call — tight buffer
+const estimate = await publicClient.estimateGas({ to, data });
+const gasLimit = estimate + estimate / 10n; // 10% max
+```
+
+## EIP-1559 pricing
+
+Standard type 2 transactions:
+
+```
+price_per_gas = min(base_price_per_gas + priority_price_per_gas, max_price_per_gas)
+```
+
+The user signs `priority_price_per_gas` (tip) and `max_price_per_gas` (cap). The network controls `base_price_per_gas` for all transactions in a block.
+
+## Block and transaction limits
+
+| Parameter | Value |
+| --- | --- |
+| Block gas limit | 200M gas |
+| Transaction gas limit | 30M gas |
+| Minimum base fee | 100 MON-gwei (100 × 10⁻⁹ MON) |
+
+Block gas limit is ~6.7× Ethereum's, so blocks fit substantially more transactions.
+
+## Base fee controller
+
+Monad's base fee controller **increases more slowly and decreases more quickly** than Ethereum's, to prevent blockspace underutilization from overpricing. Parameters:
+
+| Param | Value |
+| --- | --- |
+| `max_step_size` | 1/28 |
+| `target` | 160M gas (80% of block capacity) |
+| `beta` | 0.96 |
+| `epsilon` | 160M |
+
+Exponential smoothing (`beta = 0.96`) tracks historical variance in block fullness, producing smoother transitions than Ethereum's simpler mechanism. **In practice: gas prices on Monad are more stable and recover faster after spikes.**
+
+## Transaction ordering
+
+The default Monad client uses a **Priority Gas Auction**: transactions sorted by descending total gas price (base + priority).
+
+## Opcode repricing
+
+Monad **raises** a few opcode prices (rather than discounting everything) to reflect different resource scarcity:
+
+### Cold state access (3-4× more expensive)
+
+| Operation | Ethereum | Monad |
+| --- | --- | --- |
+| Account access (cold) | 2,600 gas | **10,100 gas** |
+| Storage access (cold) | 2,100 gas | **8,100 gas** |
+| Account access (warm) | 100 gas | 100 gas (unchanged) |
+| Storage access (warm) | 100 gas | 100 gas (unchanged) |
+
+**Affected opcodes:** `BALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`, `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, `SELFDESTRUCT`, `SLOAD`, `SSTORE`.
+
+**What this means:** Contracts that touch many cold storage slots or call many external contracts cost significantly more on Monad. Patterns that read a slot once (cold) then reuse it (warm) are fine. Patterns that do single cold reads across many slots are expensive.
+
+### Cryptographic precompiles (2-5× more expensive)
+
+| Precompile | Address | Ethereum | Monad | Multiplier |
+| --- | --- | --- | --- | --- |
+| ecRecover | `0x01` | 3,000 | 6,000 | 2× |
+| ecAdd | `0x06` | 150 | 300 | 2× |
+| ecMul | `0x07` | 6,000 | 30,000 | **5×** |
+| ecPairing | `0x08` | 45,000 | 225,000 | **5×** |
+| blake2f | `0x09` | rounds × 1 | rounds × 2 | 2× |
+| point evaluation | `0x0a` | 50,000 | 200,000 | 4× |
+
+**What this means:** Signature-verification-heavy contracts (`ecRecover`) cost 2× the gas. On-chain ZK verification (`ecMul`, `ecPairing`, point evaluation) is **4-5×** more expensive — Ethereum gas estimates will be significantly low.
+
+## Showing gas costs in UI
+
+Calculate from `gas_limit`, **not** `gas_used` from receipts (which is what Ethereum docs and most wallets do by default):
+
+```typescript
+const gasCost = gasLimit * gasPrice; // not receipt.gasUsed * gasPrice
+```
+
+## Upstream reference
+
+Full monskills `gas/` skill: https://github.com/therealharpaljadeja/monskills/blob/main/gas/SKILL.md

--- a/skills/ecosystem/monad/references/indexer.md
+++ b/skills/ecosystem/monad/references/indexer.md
@@ -1,0 +1,112 @@
+# Monad Indexer (HyperIndex on Envio Cloud)
+
+For activity feeds, leaderboards, transaction history, analytics dashboards, or anything else that needs to read **historical** on-chain events on Monad — Alchemy does not yet provide a Transfers / NFT / Token API for Monad mainnet, so the Monad-native path is HyperIndex deployed on Envio Cloud.
+
+## When to use HyperIndex on Monad
+
+- Building a frontend that needs more than a single `eth_call` can provide — pagination across history, multi-contract joins, filtered streams, leaderboards.
+- Capturing on-chain events as triggers for off-chain logic.
+- Activity feeds, transaction history pages, analytics dashboards.
+
+For one-shot reads or live state, use `alchemy-cli` / `alchemy-api` JSON-RPC instead.
+
+## Prerequisites
+
+The user must have **all four** of these in place before any indexer command works:
+
+1. `envio-cloud` installed globally — `npm install -g envio-cloud`
+2. `envio-cloud` logged in — `envio-cloud login` (browser flow, 30-day session)
+3. GitHub CLI installed — `brew install gh` on macOS, or see https://cli.github.com
+4. GitHub CLI logged in — `gh auth login`
+
+GitHub is required because Envio Cloud deploys from GitHub.
+
+**Do not install either CLI on the user's behalf, and do not run `login` for them.** If anything is missing, surface the exact command and wait.
+
+The contract you're indexing must be **deployed AND verified** on a Monad explorer before `contract-import` runs. `contract-import` pulls the ABI from the explorer — unverified contract = import failure.
+
+## Initialize an indexer
+
+Run inside an `indexer/` folder at the project root.
+
+### Monad mainnet
+
+```bash
+mkdir -p indexer && cd indexer
+pnpx envio@3.0.0-alpha.21 init contract-import explorer \
+  -b monad \
+  -c <CONTRACT_ADDRESS> \
+  -n <CONTRACT_NAME> \
+  -l typescript \
+  -d ./ -o ./ \
+  --all-events --single-contract --api-token ""
+```
+
+### Monad testnet
+
+```bash
+mkdir -p indexer && cd indexer
+pnpx envio@3.0.0-alpha.21 init contract-import explorer \
+  -b monad-testnet \
+  -c <CONTRACT_ADDRESS> \
+  -n <CONTRACT_NAME> \
+  -l typescript \
+  -d ./ -o ./ \
+  --all-events --single-contract --api-token ""
+```
+
+**Notes:**
+
+- `<CONTRACT_NAME>` should match the Solidity contract name (e.g. `MyToken`).
+- `--all-events` imports every event in the ABI. Narrow later by editing `config.yaml`.
+- `--single-contract` scaffolds for one contract. Re-run for additional contracts or hand-edit the config.
+- `--api-token ""` is intentional — leave it empty.
+- `-l typescript` is a flag, not a positional — the CLI rejects bare `typescript`.
+- Version is pinned to `envio@3.0.0-alpha.21` — use exactly this.
+
+## Opt into transaction fields before writing handlers
+
+By default `event.transaction.*` is typed `never` in generated handlers — accessing `event.transaction.hash` (or any other tx field) is a TypeScript error. Most frontends want the tx hash for explorer links and dedup, so opt in **before** writing handler code.
+
+Add to `config.yaml` (top level, sibling of `networks:` / `contracts:`):
+
+```yaml
+field_selection:
+  transaction_fields:
+    - hash
+```
+
+After editing, re-run codegen so the types regenerate:
+
+```bash
+pnpm codegen
+# or
+pnpx envio@3.0.0-alpha.21 codegen
+```
+
+Add other fields the handlers need (`from`, `to`, `value`, `gasUsed`, `input`, etc.) to the same list. Envio only pulls and types the fields listed, so keep it minimal.
+
+Full field list: https://docs.envio.dev/docs/HyperIndex/configuration-file#field-selection
+
+## Exit-code contract
+
+Every `envio-cloud` command follows the same convention — check this, not just stdout:
+
+| Exit code | Meaning | Reaction |
+| --- | --- | --- |
+| `0` | Success | Continue |
+| `1` | User error (bad args, unknown indexer, not logged in) | Read stderr, fix the input, retry |
+| `2` | API / server error (not the user's fault) | Retry once. If it persists, surface to the user and stop. |
+
+## What's covered in upstream monskills
+
+The upstream `indexer/` skill in `therealharpaljadeja/monskills` covers in detail:
+
+- **Workflow recipes** — first deploy, debugging failed deploys, env-var rotation, IP allowlisting.
+- **CLI reference** — every `envio-cloud` command grouped by area (auth, context, indexer lifecycle, deployment, env, security).
+
+Install the full skill via `npx skills add therealharpaljadeja/monskills` or browse: https://github.com/therealharpaljadeja/monskills/tree/main/indexer
+
+## Official Envio docs
+
+https://docs.envio.dev/docs/HyperIndex/envio-cloud-cli


### PR DESCRIPTION
## Summary

- Adds **Monad** as an ecosystem partner skill (`skills/ecosystem/monad/`), curated subset of [`therealharpaljadeja/monskills`](https://github.com/therealharpaljadeja/monskills)
- Covers Monad-specific topics: architecture concepts (async / parallel execution, EIP-7702, block states, reserve balance), gas pricing rules (`gas_limit` not `gas_used`, opcode repricing), canonical contract addresses on Monad mainnet, and HyperIndex (Envio Cloud) for on-chain event indexing
- Adds the path to `.claude-plugin/plugin.json` so the Vercel `npx skills` CLI discovers it

## Scope

**In:** Monad concepts that differ from Ethereum (async/parallel execution, 10 MON reserve balance floor, native EIP-7702), gas pricing rules (cold state 3-4× more expensive, precompiles 2-5×), canonical addresses (Wrapped MON, ERC-4337 EntryPoint v0.6/v0.7, Safe, Multicall3, Permit2, bridged stables/ETH/BTC, ERC-8004 agent registry), HyperIndex indexer setup on Envio Cloud.

**Out (routes back to first-party Alchemy):**
- Live JSON-RPC queries on Monad → `alchemy-cli` / `alchemy-mcp`
- App-code JSON-RPC on Monad → `alchemy-api` (with API key) or `alchemy-agentic-gateway` (without)
- Account Kit / Bundler / Smart Account for agent wallets on Monad → `alchemy-cli` / `alchemy-api`
- Gas Manager / paymaster on Monad → `alchemy-cli` / `alchemy-api`
- Token / NFT / Prices / Portfolio on Monad → not yet supported by Alchemy; routed to the on-chain indexer reference

## Notes

- Alchemy's Token / NFT / Prices / Portfolio APIs do **not** yet support Monad mainnet, so those needs are explicitly routed to the on-chain indexer in `scope_out`
- Reciprocal PR adding Alchemy's RPC + Account Kit + Gas Manager to `therealharpaljadeja/monskills` is coming next

Made with [Cursor](https://cursor.com)